### PR TITLE
feat: add setup-mcp command for cross-platform MCP server registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,12 @@ npm install -g @anthropic-ai/claude-code
 
 ```bash
 npx mcp-voice-hooks@latest install-hooks
-claude mcp add voice-hooks npx mcp-voice-hooks@latest
+npx mcp-voice-hooks@latest setup-mcp
 ```
+
+The `setup-mcp` command automatically detects your operating system and configures the MCP server correctly:
+- **Windows**: Uses `cmd /c npx` wrapper (required because npx.cmd is a batch file)
+- **Mac/Linux**: Uses `npx` directly
 
 ## Usage
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -27,7 +27,11 @@ async function main() {
       await configureClaudeCodeSettings();
 
       console.log('\n✅ Installation complete!');
-      console.log('📝 To add the server to Claude Code, run: `claude mcp add voice-hooks npx mcp-voice-hooks@latest`');
+      console.log('📝 To add the server to Claude Code, run: `npx mcp-voice-hooks@latest setup-mcp`');
+    } else if (command === 'setup-mcp') {
+      // Cross-platform MCP server registration
+      console.log('🔧 Setting up MCP server for Claude Code...');
+      await setupMCPServer();
     } else if (command === 'uninstall') {
       console.log('🗑️  Uninstalling MCP Voice Hooks...');
       await uninstall();
@@ -128,6 +132,59 @@ async function configureClaudeCodeSettings() {
   // Write settings back
   fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
   console.log('✅ Updated project Claude Code settings');
+}
+
+// Cross-platform MCP server setup
+async function setupMCPServer() {
+  const isWindows = process.platform === 'win32';
+
+  console.log(`📍 Detected platform: ${isWindows ? 'Windows' : 'Mac/Linux'}`);
+
+  // Build the appropriate command based on OS
+  let mcpCommand, mcpArgs;
+
+  if (isWindows) {
+    // Windows needs cmd /c wrapper because npx is a batch file (npx.cmd)
+    mcpCommand = 'cmd';
+    mcpArgs = ['/c', 'npx', 'mcp-voice-hooks@latest'];
+    console.log('🪟 Using Windows-compatible command wrapper (cmd /c)');
+  } else {
+    // Mac/Linux can run npx directly
+    mcpCommand = 'npx';
+    mcpArgs = ['mcp-voice-hooks@latest'];
+  }
+
+  // Run claude mcp add command
+  const claudeArgs = ['mcp', 'add', 'voice-hooks', mcpCommand, ...mcpArgs];
+  console.log(`🔄 Running: claude ${claudeArgs.join(' ')}`);
+
+  return new Promise((resolve, reject) => {
+    const child = spawn('claude', claudeArgs, {
+      stdio: 'inherit',
+      shell: isWindows // Use shell on Windows for better compatibility
+    });
+
+    child.on('error', (error) => {
+      console.error('❌ Failed to run claude mcp add:', error.message);
+      console.log('\n💡 Make sure Claude Code CLI is installed: npm install -g @anthropic-ai/claude-code');
+      reject(error);
+    });
+
+    child.on('exit', (code) => {
+      if (code === 0) {
+        console.log('\n✅ MCP server registered successfully!');
+        console.log('🎤 Voice hooks is now ready to use.');
+        console.log('\n📝 Next steps:');
+        console.log('   1. Start Claude Code: claude');
+        console.log('   2. The browser interface will open automatically');
+        console.log('   3. Click "Start Listening" and start talking!');
+        resolve();
+      } else {
+        console.error(`❌ claude mcp add exited with code ${code}`);
+        reject(new Error(`Exit code: ${code}`));
+      }
+    });
+  });
 }
 
 // Silent hook installation check - runs on every startup


### PR DESCRIPTION
## Summary
- Adds new `setup-mcp` command that auto-detects Windows vs Mac/Linux
- On Windows, uses `cmd /c npx` wrapper (required because npx.cmd is a batch file)
- On Mac/Linux, uses `npx` directly
- Updates README with new installation instructions

## Problem
On Windows, npx is actually a batch file (`npx.cmd`), which cannot be executed directly by Claude Code's MCP system. This causes the voice-hooks MCP server to fail to start on Windows with a cryptic error.

## Solution
The new `setup-mcp` command detects `process.platform === 'win32'` and configures the MCP server correctly:

```bash
# Users now just run:
npx mcp-voice-hooks@latest setup-mcp

# On Windows, this runs:
claude mcp add voice-hooks cmd /c npx mcp-voice-hooks@latest

# On Mac/Linux, this runs:
claude mcp add voice-hooks npx mcp-voice-hooks@latest
```

## Test plan
- [x] Tested on Windows - correctly detects platform and uses cmd /c wrapper
- [ ] Needs testing on Mac/Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)