### PR TITLE
feat: prevent TTS playback while user is speaking

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1205,6 +1205,12 @@ class MessengerClient {
                         pcm16[i] = s < 0 ? s * 0x8000 : s * 0x7FFF;
                     }
                     this.audioWs.send(pcm16.buffer);
+                } else if (e.data.type === 'vad') {
+                    // Audio-level VAD from the worklet — instant detection
+                    if (this.audioWs && this.audioWs.readyState === WebSocket.OPEN) {
+                        const msgType = e.data.speaking ? 'user-speaking-start' : 'user-speaking-stop';
+                        this.audioWs.send(JSON.stringify({ type: msgType }));
+                    }
                 }
             };
 

--- a/public/app.js
+++ b/public/app.js
@@ -197,6 +197,8 @@ class MessengerClient {
                     this.audioPlayer.clear();
                 } else if (data.type === 'waitStatus') {
                     this.handleWaitStatus(data.isWaiting);
+                } else if (data.type === 'user-speaking') {
+                    this.handleUserSpeaking(data.speaking);
                 } else if (data.type === 'session-reset') {
                     // New Claude session started — re-sync our voice state with the server
                     console.log('[SSE] New Claude session detected, re-syncing voice state');
@@ -213,6 +215,13 @@ class MessengerClient {
             this.currentVoiceState = 'inactive';
             this.updateVoiceStateUI('inactive');
         };
+    }
+
+    handleUserSpeaking(speaking) {
+        const indicator = document.getElementById('userSpeakingIndicator');
+        if (indicator) {
+            indicator.style.display = speaking ? 'block' : 'none';
+        }
     }
 
     handleWaitStatus(isWaiting) {

--- a/public/app.js
+++ b/public/app.js
@@ -254,8 +254,10 @@ class MessengerClient {
             this.updateStatusIndicator('speaking', 'Claude is speaking...');
         } else if (state === 'stopped') {
             this.updateStatusIndicator('stopped', 'Claude\'s turn ended');
+        } else if (state === 'inactive') {
+            this.updateStatusIndicator('idle', 'Idle');
         } else {
-            this.updateStatusIndicator('', '');
+            this.updateStatusIndicator('idle', 'Idle');
         }
     }
 

--- a/public/app.js
+++ b/public/app.js
@@ -227,14 +227,16 @@ class MessengerClient {
             }
             this.updateStatusIndicator('user-speaking', '🎤 User speaking');
         } else {
-            // Delay clearing by 1s to prevent flickering during natural speech pauses
+            // Delay clearing by 2s to prevent flickering during natural speech pauses.
+            // The server debounces stop events by 1s, so we add extra buffer here
+            // to keep the indicator stable throughout natural inter-sentence pauses.
             if (this._userSpeakingHideTimer) clearTimeout(this._userSpeakingHideTimer);
             this._userSpeakingHideTimer = setTimeout(() => {
                 this._userSpeakingActive = false;
                 this._userSpeakingHideTimer = null;
                 // Restore the voice state after user stops speaking
                 this.updateVoiceStateUI(this.currentVoiceState);
-            }, 1000);
+            }, 2000);
         }
     }
 

--- a/public/app.js
+++ b/public/app.js
@@ -820,10 +820,9 @@ class MessengerClient {
             // Open WebSocket; audio capture starts from the onopen callback
             this.connectAudioWebSocket();
 
-            // Start browser speech recognition
-            // When using server recognition, browser STT still runs for VAD events
-            // (onspeechstart/onspeechend) — transcript results are skipped
-            if (this.recognition) {
+            // Start browser speech recognition only if NOT using server recognition
+            // (worklet audio-level VAD handles voice activity detection for server mode)
+            if (!this.useServerRecognition && this.recognition) {
                 this.recognition.start();
             }
 
@@ -899,20 +898,7 @@ class MessengerClient {
             }
         };
 
-        // VAD events — send to server for user-speaking state machine
-        this.recognition.onspeechstart = () => {
-            console.log('[VAD] Speech started');
-            if (this.wsAudioClient?.readyState === WebSocket.OPEN) {
-                this.wsAudioClient.send(JSON.stringify({ type: 'user-speaking-start' }));
-            }
-        };
-
-        this.recognition.onspeechend = () => {
-            console.log('[VAD] Speech ended');
-            if (this.wsAudioClient?.readyState === WebSocket.OPEN) {
-                this.wsAudioClient.send(JSON.stringify({ type: 'user-speaking-stop' }));
-            }
-        };
+        // Browser STT VAD removed — worklet audio-level VAD handles this now
 
         this.recognition.onerror = (event) => {
             if (event.error !== 'no-speech') {

--- a/public/app.js
+++ b/public/app.js
@@ -218,53 +218,61 @@ class MessengerClient {
     }
 
     handleUserSpeaking(speaking) {
-        const userIndicator = document.getElementById('userSpeakingIndicator');
-        const waitIndicator = document.getElementById('waitingIndicator');
-        if (userIndicator) {
-            userIndicator.style.display = speaking ? 'block' : 'none';
-        }
-        // Hide waiting indicator when user is speaking
-        if (waitIndicator && speaking) {
-            waitIndicator.style.display = 'none';
+        this._userSpeakingActive = speaking;
+        if (speaking) {
+            // Show immediately, cancel any pending clear
+            if (this._userSpeakingHideTimer) {
+                clearTimeout(this._userSpeakingHideTimer);
+                this._userSpeakingHideTimer = null;
+            }
+            this.updateStatusIndicator('user-speaking', '🎤 User speaking');
+        } else {
+            // Delay clearing by 1s to prevent flickering during natural speech pauses
+            if (this._userSpeakingHideTimer) clearTimeout(this._userSpeakingHideTimer);
+            this._userSpeakingHideTimer = setTimeout(() => {
+                this._userSpeakingActive = false;
+                this._userSpeakingHideTimer = null;
+                // Restore the voice state after user stops speaking
+                this.updateVoiceStateUI(this.currentVoiceState);
+            }, 1000);
         }
     }
 
     handleWaitStatus(isWaiting) {
-        // Fallback handler for waitStatus SSE events.
-        // voice-state SSE events are now the primary driver for UI state.
-        const waitingIndicator = document.getElementById('waitingIndicator');
-        if (waitingIndicator) {
-            const wasAtBottom = this.isUserNearBottom();
-            waitingIndicator.style.display = isWaiting ? 'block' : 'none';
-            if (isWaiting && wasAtBottom) {
-                this.scrollToBottom();
-            }
-        }
+        // No-op — unified status indicator is now driven by updateVoiceStateUI
     }
 
     updateVoiceStateUI(state) {
-        const waitingIndicator = document.getElementById('waitingIndicator');
-        if (!waitingIndicator) return;
+        // Don't override user-speaking indicator
+        if (this._userSpeakingActive) return;
+
+        if (state === 'listening') {
+            this.updateStatusIndicator('listening', 'Claude is waiting...');
+        } else if (state === 'processing') {
+            this.updateStatusIndicator('processing', 'Claude is processing...');
+        } else if (state === 'speaking') {
+            this.updateStatusIndicator('speaking', 'Claude is speaking...');
+        } else if (state === 'stopped') {
+            this.updateStatusIndicator('stopped', 'Claude\'s turn ended');
+        } else {
+            this.updateStatusIndicator('', '');
+        }
+    }
+
+    updateStatusIndicator(className, text) {
+        const indicator = document.getElementById('statusIndicator');
+        if (!indicator) return;
 
         const wasAtBottom = this.isUserNearBottom();
 
-        if (state === 'listening') {
-            waitingIndicator.textContent = 'Claude is waiting...';
-            waitingIndicator.style.display = 'block';
-        } else if (state === 'processing') {
-            waitingIndicator.textContent = 'Claude is processing...';
-            waitingIndicator.style.display = 'block';
-        } else if (state === 'speaking') {
-            waitingIndicator.textContent = 'Claude is speaking...';
-            waitingIndicator.style.display = 'block';
-        } else if (state === 'stopped') {
-            waitingIndicator.textContent = 'Claude\'s turn ended';
-            waitingIndicator.style.display = 'block';
-        } else {
-            waitingIndicator.style.display = 'none';
+        // Remove all state classes
+        indicator.className = 'status-indicator';
+        if (className) {
+            indicator.classList.add(className);
         }
+        indicator.textContent = text;
 
-        if (state !== 'inactive' && wasAtBottom) {
+        if (text && wasAtBottom) {
             this.scrollToBottom();
         }
     }
@@ -624,7 +632,7 @@ class MessengerClient {
         });
 
         // Get waiting indicator to insert messages before it
-        const waitingIndicator = container.querySelector('.waiting-indicator');
+        const statusIndicator = container.querySelector('.status-indicator');
 
         // Check if user is near bottom before adding content
         const wasAtBottom = this.isUserNearBottom();
@@ -632,10 +640,10 @@ class MessengerClient {
         // Only render new messages and update status for existing ones
         messages.forEach(message => {
             if (!existingIds.has(message.id)) {
-                // New message - create bubble and insert before waiting indicator
+                // New message - create bubble and insert before status indicator
                 const bubble = this.createMessageBubble(message);
-                if (waitingIndicator) {
-                    container.insertBefore(bubble, waitingIndicator);
+                if (statusIndicator) {
+                    container.insertBefore(bubble, statusIndicator);
                 } else {
                     container.appendChild(bubble);
                 }
@@ -810,8 +818,10 @@ class MessengerClient {
             // Open WebSocket; audio capture starts from the onopen callback
             this.connectAudioWebSocket();
 
-            // Start browser speech recognition only if NOT using server recognition
-            if (!this.useServerRecognition && this.recognition) {
+            // Start browser speech recognition
+            // When using server recognition, browser STT still runs for VAD events
+            // (onspeechstart/onspeechend) — transcript results are skipped
+            if (this.recognition) {
                 this.recognition.start();
             }
 
@@ -884,6 +894,21 @@ class MessengerClient {
                 this.messageInput.value = interimTranscript;
                 this.isInterimText = true;
                 this.autoGrowTextarea();
+            }
+        };
+
+        // VAD events — send to server for user-speaking state machine
+        this.recognition.onspeechstart = () => {
+            console.log('[VAD] Speech started');
+            if (this.wsAudioClient?.readyState === WebSocket.OPEN) {
+                this.wsAudioClient.send(JSON.stringify({ type: 'user-speaking-start' }));
+            }
+        };
+
+        this.recognition.onspeechend = () => {
+            console.log('[VAD] Speech ended');
+            if (this.wsAudioClient?.readyState === WebSocket.OPEN) {
+                this.wsAudioClient.send(JSON.stringify({ type: 'user-speaking-stop' }));
             }
         };
 

--- a/public/app.js
+++ b/public/app.js
@@ -218,9 +218,14 @@ class MessengerClient {
     }
 
     handleUserSpeaking(speaking) {
-        const indicator = document.getElementById('userSpeakingIndicator');
-        if (indicator) {
-            indicator.style.display = speaking ? 'block' : 'none';
+        const userIndicator = document.getElementById('userSpeakingIndicator');
+        const waitIndicator = document.getElementById('waitingIndicator');
+        if (userIndicator) {
+            userIndicator.style.display = speaking ? 'block' : 'none';
+        }
+        // Hide waiting indicator when user is speaking
+        if (waitIndicator && speaking) {
+            waitIndicator.style.display = 'none';
         }
     }
 

--- a/public/audio-capture-worklet.js
+++ b/public/audio-capture-worklet.js
@@ -22,7 +22,7 @@ class AudioCaptureProcessor extends AudioWorkletProcessor {
     this._speakingThreshold = 0.01;  // RMS threshold for speech detection
     this._silenceThreshold = 0.005;  // RMS threshold for silence (hysteresis)
     this._silenceFrames = 0;
-    this._silenceFramesRequired = 40; // ~800ms at 128 samples/frame @ 48kHz
+    this._silenceFramesRequired = 300; // ~800ms at 128 samples/frame @ 48kHz (128/48000 = 2.67ms/frame)
   }
 
   downsample(buffer, ratio) {

--- a/public/audio-capture-worklet.js
+++ b/public/audio-capture-worklet.js
@@ -22,7 +22,7 @@ class AudioCaptureProcessor extends AudioWorkletProcessor {
     this._speakingThreshold = 0.01;  // RMS threshold for speech detection
     this._silenceThreshold = 0.005;  // RMS threshold for silence (hysteresis)
     this._silenceFrames = 0;
-    this._silenceFramesRequired = 15; // ~300ms at 128 samples/frame @ 48kHz
+    this._silenceFramesRequired = 40; // ~800ms at 128 samples/frame @ 48kHz
   }
 
   downsample(buffer, ratio) {

--- a/public/audio-capture-worklet.js
+++ b/public/audio-capture-worklet.js
@@ -20,9 +20,9 @@ class AudioCaptureProcessor extends AudioWorkletProcessor {
     // VAD: audio power level tracking
     this._speaking = false;
     this._speakingThreshold = 0.01;  // RMS threshold for speech detection
-    this._silenceThreshold = 0.005;  // RMS threshold for silence (hysteresis)
+    this._silenceThreshold = 0.003;  // RMS threshold for silence (hysteresis, lowered to catch quiet speech)
     this._silenceFrames = 0;
-    this._silenceFramesRequired = 300; // ~800ms at 128 samples/frame @ 48kHz (128/48000 = 2.67ms/frame)
+    this._silenceFramesRequired = 560; // ~1.5s at 128 samples/frame @ 48kHz (128/48000 = 2.67ms/frame)
   }
 
   downsample(buffer, ratio) {

--- a/public/audio-capture-worklet.js
+++ b/public/audio-capture-worklet.js
@@ -17,6 +17,12 @@ class AudioCaptureProcessor extends AudioWorkletProcessor {
     this.ratio = sampleRate / this.targetRate;
     // Number of native-rate samples needed to produce one 20ms output frame (320 samples)
     this.inputFrameSize = Math.round(320 * this.ratio);
+    // VAD: audio power level tracking
+    this._speaking = false;
+    this._speakingThreshold = 0.01;  // RMS threshold for speech detection
+    this._silenceThreshold = 0.005;  // RMS threshold for silence (hysteresis)
+    this._silenceFrames = 0;
+    this._silenceFramesRequired = 15; // ~300ms at 128 samples/frame @ 48kHz
   }
 
   downsample(buffer, ratio) {
@@ -31,6 +37,30 @@ class AudioCaptureProcessor extends AudioWorkletProcessor {
   process(inputs) {
     const input = inputs[0]?.[0]; // mono channel
     if (!input) return true;
+
+    // VAD: compute RMS power of this frame
+    let sumSq = 0;
+    for (let i = 0; i < input.length; i++) {
+      sumSq += input[i] * input[i];
+    }
+    const rms = Math.sqrt(sumSq / input.length);
+
+    if (!this._speaking && rms > this._speakingThreshold) {
+      this._speaking = true;
+      this._silenceFrames = 0;
+      this.port.postMessage({ type: 'vad', speaking: true });
+    } else if (this._speaking) {
+      if (rms < this._silenceThreshold) {
+        this._silenceFrames++;
+        if (this._silenceFrames >= this._silenceFramesRequired) {
+          this._speaking = false;
+          this._silenceFrames = 0;
+          this.port.postMessage({ type: 'vad', speaking: false });
+        }
+      } else {
+        this._silenceFrames = 0;
+      }
+    }
 
     // Accumulate samples at native rate
     const newBuffer = new Float32Array(this.buffer.length + input.length);

--- a/public/index.html
+++ b/public/index.html
@@ -157,6 +157,18 @@
             font-size: 16px;
         }
 
+        /* User Speaking Indicator */
+        .user-speaking-indicator {
+            text-align: center;
+            color: #e74c3c;
+            font-size: 14px;
+            font-weight: bold;
+            padding: 8px 20px;
+            margin-top: 8px;
+            background: rgba(231, 76, 60, 0.1);
+            border-radius: 8px;
+        }
+
         /* Waiting Indicator */
         .waiting-indicator {
             text-align: center;
@@ -908,6 +920,9 @@
                                 <path d="M20 2H4c-1.1 0-2 .9-2 2v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2z"/>
                             </svg>
                             <p id="emptyStateMessage">No messages yet. Type or speak to start the conversation!</p>
+                        </div>
+                        <div id="userSpeakingIndicator" class="user-speaking-indicator" style="display: none;">
+                            🎤 User speaking (pre-speak blocked)
                         </div>
                         <div id="waitingIndicator" class="waiting-indicator" style="display: none;">
                             Claude is waiting...

--- a/public/index.html
+++ b/public/index.html
@@ -157,26 +157,35 @@
             font-size: 16px;
         }
 
-        /* User Speaking Indicator */
-        .user-speaking-indicator {
+        /* Unified Status Indicator */
+        .status-indicator {
             text-align: center;
-            color: #e74c3c;
             font-size: 14px;
-            font-weight: bold;
             padding: 8px 20px;
             margin-top: 8px;
+            min-height: 20px;
+        }
+        .status-indicator.user-speaking {
+            color: #e74c3c;
+            font-weight: bold;
             background: rgba(231, 76, 60, 0.1);
             border-radius: 8px;
         }
-
-        /* Waiting Indicator */
-        .waiting-indicator {
-            text-align: center;
+        .status-indicator.listening {
             color: #999;
-            font-size: 14px;
             font-style: italic;
-            padding: 12px 20px;
-            margin-top: 8px;
+        }
+        .status-indicator.processing {
+            color: #f39c12;
+            font-style: italic;
+        }
+        .status-indicator.speaking {
+            color: #3498db;
+            font-style: italic;
+        }
+        .status-indicator.stopped {
+            color: #999;
+            font-style: italic;
         }
 
         /* Message Bubbles */
@@ -921,12 +930,7 @@
                             </svg>
                             <p id="emptyStateMessage">No messages yet. Type or speak to start the conversation!</p>
                         </div>
-                        <div id="userSpeakingIndicator" class="user-speaking-indicator" style="display: none;">
-                            🎤 User speaking (pre-speak blocked)
-                        </div>
-                        <div id="waitingIndicator" class="waiting-indicator" style="display: none;">
-                            Claude is waiting...
-                        </div>
+                        <div id="statusIndicator" class="status-indicator"></div>
                     </div>
                 </div>
             </div>

--- a/public/index.html
+++ b/public/index.html
@@ -157,35 +157,35 @@
             font-size: 16px;
         }
 
-        /* Unified Status Indicator */
+        /* Unified Status Indicator — always visible */
         .status-indicator {
             text-align: center;
-            font-size: 14px;
-            padding: 8px 20px;
+            font-size: 13px;
+            padding: 6px 20px;
             margin-top: 8px;
             min-height: 20px;
+            color: #999;
+            font-style: italic;
         }
         .status-indicator.user-speaking {
             color: #e74c3c;
             font-weight: bold;
-            background: rgba(231, 76, 60, 0.1);
-            border-radius: 8px;
+            font-style: normal;
         }
         .status-indicator.listening {
             color: #999;
-            font-style: italic;
         }
         .status-indicator.processing {
             color: #f39c12;
-            font-style: italic;
         }
         .status-indicator.speaking {
             color: #3498db;
-            font-style: italic;
         }
         .status-indicator.stopped {
             color: #999;
-            font-style: italic;
+        }
+        .status-indicator.idle {
+            color: #666;
         }
 
         /* Message Bubbles */
@@ -930,7 +930,7 @@
                             </svg>
                             <p id="emptyStateMessage">No messages yet. Type or speak to start the conversation!</p>
                         </div>
-                        <div id="statusIndicator" class="status-indicator"></div>
+                        <div id="statusIndicator" class="status-indicator idle">Idle</div>
                     </div>
                 </div>
             </div>

--- a/src/__tests__/pre-speak-user-speaking.test.ts
+++ b/src/__tests__/pre-speak-user-speaking.test.ts
@@ -105,6 +105,49 @@ describe('Pre-speak hook: block while user is speaking', () => {
     expect(data.decision).toBe('approve');
   });
 
+  it('should block with utterances when finalized text arrives after user stops speaking', async () => {
+    server.isUserSpeaking = true;
+
+    const requestPromise = preSpeakRequest();
+
+    // Finalized text arrives while user is still speaking
+    setTimeout(async () => {
+      await fetch(`${server.url}/api/potential-utterances`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: 'Actually wait, I changed my mind' })
+      });
+    }, 100);
+
+    // User stops speaking after 200ms
+    setTimeout(() => {
+      server.isUserSpeaking = false;
+    }, 200);
+
+    const response = await requestPromise;
+    const data = await response.json() as any;
+
+    expect(data.decision).toBe('block');
+    expect(data.reason).toContain('Actually wait');
+  });
+
+  it('should approve when user stops speaking and no text arrives during grace period', async () => {
+    server.isUserSpeaking = true;
+
+    const requestPromise = preSpeakRequest();
+
+    // User stops speaking after 200ms — no utterance added
+    setTimeout(() => {
+      server.isUserSpeaking = false;
+    }, 200);
+
+    const response = await requestPromise;
+    const data = await response.json() as any;
+
+    // No finalized text after grace period — false alarm, approve
+    expect(data.decision).toBe('approve');
+  });
+
   it('should measure blocking duration approximately matches user speaking duration', async () => {
     server.isUserSpeaking = true;
     const startTime = Date.now();

--- a/src/__tests__/pre-speak-user-speaking.test.ts
+++ b/src/__tests__/pre-speak-user-speaking.test.ts
@@ -1,0 +1,126 @@
+import { TestServer } from '../test-utils/test-server.js';
+
+describe('Pre-speak hook: block while user is speaking', () => {
+  let server: TestServer;
+
+  beforeEach(async () => {
+    server = new TestServer();
+    await server.start();
+
+    // Enable voice
+    await fetch(`${server.url}/api/voice-active`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ active: true })
+    });
+
+    // Make a pre-speak request to register the session as active
+    await fetch(`${server.url}/api/hooks/pre-speak`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        session_id: 'test-session',
+        tool_input: { text: 'init' }
+      })
+    });
+  });
+
+  afterEach(async () => {
+    // Ensure isUserSpeaking is cleared so server can shut down cleanly
+    server.isUserSpeaking = false;
+    await server.stop();
+  });
+
+  function preSpeakRequest(text: string = 'Hello world') {
+    return fetch(`${server.url}/api/hooks/pre-speak`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        session_id: 'test-session',
+        tool_input: { text }
+      })
+    });
+  }
+
+  it('should approve immediately when user is not speaking', async () => {
+    server.isUserSpeaking = false;
+
+    const response = await preSpeakRequest();
+    const data = await response.json() as any;
+
+    expect(data.decision).toBe('approve');
+  });
+
+  it('should block and wait when user is speaking, then approve after silence', async () => {
+    server.isUserSpeaking = true;
+
+    // Start the pre-speak request (it will block)
+    const requestPromise = preSpeakRequest();
+
+    // Simulate user stopping speaking after 200ms
+    setTimeout(() => {
+      server.isUserSpeaking = false;
+    }, 200);
+
+    const response = await requestPromise;
+    const data = await response.json() as any;
+
+    expect(data.decision).toBe('approve');
+  });
+
+  it('should still block for pending utterances even when user is speaking', async () => {
+    // Add a pending utterance to the active session
+    await fetch(`${server.url}/api/potential-utterances`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: 'Hey Claude' })
+    });
+
+    server.isUserSpeaking = true;
+
+    const response = await preSpeakRequest();
+    const data = await response.json() as any;
+
+    // Should block for pending utterances immediately (no user-speaking wait)
+    expect(data.decision).toBe('block');
+    expect(data.reason).toContain('pending');
+  });
+
+  it('should approve without waiting for inactive sessions (subagents)', async () => {
+    server.isUserSpeaking = true;
+
+    // Subagent: same session_id but different agent_id — this won't switch active key
+    const response = await fetch(`${server.url}/api/hooks/pre-speak`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        session_id: 'test-session',
+        agent_id: 'subagent-1',
+        tool_input: { text: 'Hello from subagent' }
+      })
+    });
+    const data = await response.json() as any;
+
+    // Inactive sessions (subagents) should approve immediately (no user-speaking check)
+    expect(data.decision).toBe('approve');
+  });
+
+  it('should measure blocking duration approximately matches user speaking duration', async () => {
+    server.isUserSpeaking = true;
+    const startTime = Date.now();
+
+    const requestPromise = preSpeakRequest();
+
+    // Stop speaking after ~300ms
+    setTimeout(() => {
+      server.isUserSpeaking = false;
+    }, 300);
+
+    await requestPromise;
+    const elapsed = Date.now() - startTime;
+
+    // Should have waited at least ~200ms but not much more than ~800ms
+    expect(elapsed).toBeGreaterThanOrEqual(200);
+    expect(elapsed).toBeLessThan(1000);
+  });
+});

--- a/src/speech-recognition.ts
+++ b/src/speech-recognition.ts
@@ -10,6 +10,11 @@ interface TranscriptResult {
   text: string;
 }
 
+interface VadResult {
+  type: 'vad';
+  speaking: string;
+}
+
 /**
  * Wraps the Swift speech-recognizer binary as a child process.
  * Reads PCM16 LE 16kHz mono audio from feedAudio() and emits
@@ -46,9 +51,13 @@ export class SpeechRecognizer extends EventEmitter {
     const rl = createInterface({ input: this.process.stdout! });
     rl.on('line', (line: string) => {
       try {
-        const result = JSON.parse(line) as TranscriptResult;
-        if (result.type === 'interim' || result.type === 'final') {
-          this.emit('transcript', result);
+        const parsed = JSON.parse(line);
+        if (parsed.type === 'interim' || parsed.type === 'final') {
+          this.emit('transcript', parsed as TranscriptResult);
+        } else if (parsed.type === 'vad') {
+          const speaking = (parsed as VadResult).speaking === 'true';
+          this.emit('vad', speaking);
+          debugLog(`[SpeechRecognizer] VAD: speaking=${speaking}`);
         }
       } catch (err) {
         debugLog('[SpeechRecognizer] Failed to parse stdout line:', line, err);

--- a/src/test-utils/test-server.ts
+++ b/src/test-utils/test-server.ts
@@ -201,6 +201,7 @@ export class TestServer {
   public speakWhitelist = new Map<string, { count: number; expiry: number; sessionKey: string }>();
   private whitelistTTL = 5000;
   public backgroundVoiceEnforcement = false;
+  public isUserSpeaking = false;
 
   constructor() {
     this.app = express();
@@ -803,13 +804,13 @@ export class TestServer {
     });
 
     // Pre-speak hook
-    this.app.post('/api/hooks/pre-speak', (req, res) => {
+    this.app.post('/api/hooks/pre-speak', async (req, res) => {
       const { key, sessionId, agentId, agentType } = this.parseCompositeKey(req.body);
       this.registerIfFirst(key);
       const session = this.getOrCreateSession(key, sessionId, agentId, agentType);
       const speakText = req.body?.tool_input?.text;
 
-      // Active session: check for pending utterances, whitelist text
+      // Active session: check for pending utterances, wait if user speaking, whitelist text
       if (this.isActiveKey(key)) {
         const pendingUtterances = session.queue.utterances.filter(u => u.status === 'pending');
         if (pendingUtterances.length > 0) {
@@ -818,6 +819,16 @@ export class TestServer {
             reason: `There are ${pendingUtterances.length} pending utterances. Please dequeue them before speaking.`
           });
           return;
+        }
+
+        // Wait if user is speaking
+        if (this.isUserSpeaking) {
+          const POLL_INTERVAL_MS = 50;
+          const MAX_WAIT_MS = 10000;
+          const startTime = Date.now();
+          while (this.isUserSpeaking && (Date.now() - startTime) < MAX_WAIT_MS) {
+            await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
+          }
         }
 
         // Whitelist the text for the speak endpoint with session key

--- a/src/test-utils/test-server.ts
+++ b/src/test-utils/test-server.ts
@@ -821,13 +821,33 @@ export class TestServer {
           return;
         }
 
-        // Wait if user is speaking
+        // Wait if user is speaking, then check for finalized text
         if (this.isUserSpeaking) {
           const POLL_INTERVAL_MS = 50;
           const MAX_WAIT_MS = 10000;
+          const GRACE_PERIOD_MS = 500;
           const startTime = Date.now();
           while (this.isUserSpeaking && (Date.now() - startTime) < MAX_WAIT_MS) {
             await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
+          }
+
+          // Grace period for finalized text
+          await new Promise(resolve => setTimeout(resolve, GRACE_PERIOD_MS));
+
+          // Check for pending utterances that arrived during speech
+          const pendingNow = session.queue.utterances.filter((u: any) => u.status === 'pending');
+          if (pendingNow.length > 0) {
+            // Dequeue and format inline
+            const dequeued = pendingNow.map((u: any) => {
+              u.status = 'delivered';
+              u.deliveredAt = new Date();
+              return u;
+            });
+            if (dequeued.length > 0) {
+              const lines = dequeued.map((u: any) => `"${u.text}"`).join('\n');
+              res.json({ decision: 'block', reason: `Assistant received voice input from the user (${dequeued.length} utterance(s)):\n\n${lines}\n\npending` });
+              return;
+            }
           }
         }
 

--- a/src/test-utils/test-server.ts
+++ b/src/test-utils/test-server.ts
@@ -831,6 +831,21 @@ export class TestServer {
             await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
           }
 
+          // On timeout, still check for utterances before approving
+          if (this.isUserSpeaking) {
+            const pendingTimeout = session.queue.utterances.filter((u: any) => u.status === 'pending');
+            if (pendingTimeout.length > 0) {
+              const dequeued = pendingTimeout.map((u: any) => { u.status = 'delivered'; u.deliveredAt = new Date(); return u; });
+              const lines = dequeued.map((u: any) => `"${u.text}"`).join('\n');
+              res.json({ decision: 'block', reason: `Assistant received voice input from the user (${dequeued.length} utterance(s)):\n\n${lines}\n\npending` });
+              return;
+            }
+            // No utterances on timeout — approve
+            if (speakText) this.addToWhitelist(speakText, key);
+            res.json({ decision: 'approve' });
+            return;
+          }
+
           // Grace period for finalized text
           await new Promise(resolve => setTimeout(resolve, GRACE_PERIOD_MS));
 

--- a/src/unified-server.ts
+++ b/src/unified-server.ts
@@ -1622,14 +1622,6 @@ function handleWsControlMessage(client: WsAudioClient, msg: { type: string; [key
       break;
     }
 
-    case 'user-speaking-start':
-      serverAudioState.setUserSpeaking(true);
-      break;
-
-    case 'user-speaking-stop':
-      serverAudioState.setUserSpeaking(false);
-      break;
-
     case 'ping':
       client.ws.send(JSON.stringify({ type: 'pong' }));
       break;

--- a/src/unified-server.ts
+++ b/src/unified-server.ts
@@ -348,7 +348,6 @@ class ServerAudioState {
   private _hookActive = false;
   private _userSpeaking = false;
   private _userSpeakingDebounceTimer: ReturnType<typeof setTimeout> | null = null;
-  private _userSpeakingSilenceTimer: ReturnType<typeof setTimeout> | null = null;
   private _pulseTimer: ReturnType<typeof setInterval> | null = null;
 
   syncState(): void {
@@ -419,13 +418,15 @@ class ServerAudioState {
 
     if (active) {
       // User started speaking — set immediately
+      if (this._userSpeakingDebounceTimer) {
+        clearTimeout(this._userSpeakingDebounceTimer);
+        this._userSpeakingDebounceTimer = null;
+      }
       if (!this._userSpeaking) {
         debugLog('[ServerAudio] userSpeaking = true');
         this._userSpeaking = true;
         this.onUserSpeakingChange?.(true);
       }
-      // Reset silence timeout (2 seconds from last speech activity)
-      this._resetSilenceTimeout();
     } else {
       // User stopped speaking — debounce 300ms to absorb gaps between words
       this._userSpeakingDebounceTimer = setTimeout(() => {
@@ -433,7 +434,6 @@ class ServerAudioState {
         if (this._userSpeaking) {
           debugLog('[ServerAudio] userSpeaking = false (debounced)');
           this._userSpeaking = false;
-          this._clearSilenceTimeout();
           this.onUserSpeakingChange?.(false);
           // Resume TTS queue now that user has stopped speaking
           processTtsQueue();
@@ -443,28 +443,8 @@ class ServerAudioState {
     this.syncState();
   }
 
-  private _resetSilenceTimeout(): void {
-    this._clearSilenceTimeout();
-    // If no transcript events arrive within 2 seconds, assume user stopped speaking
-    this._userSpeakingSilenceTimer = setTimeout(() => {
-      this._userSpeakingSilenceTimer = null;
-      if (this._userSpeaking) {
-        debugLog('[ServerAudio] userSpeaking = false (silence timeout)');
-        this._userSpeaking = false;
-        this.onUserSpeakingChange?.(false);
-        this.syncState();
-        // Resume TTS queue
-        processTtsQueue();
-      }
-    }, 2000);
-  }
-
-  private _clearSilenceTimeout(): void {
-    if (this._userSpeakingSilenceTimer) {
-      clearTimeout(this._userSpeakingSilenceTimer);
-      this._userSpeakingSilenceTimer = null;
-    }
-  }
+  // No server-side silence timeout — we rely entirely on browser worklet VAD
+  // for stop events. WebSocket disconnect handler clears speaking state as a safety net.
 
   // Callback for broadcasting state changes to SSE clients.
   // Set after ttsClients is initialised (see broadcastVoiceState helper).

--- a/src/unified-server.ts
+++ b/src/unified-server.ts
@@ -1029,8 +1029,25 @@ function handleHookRequest(attemptedAction: 'tool' | 'speak' | 'stop' | 'post-to
     return { decision: 'approve' };
   }
 
-  // 4. Handle speak
+  // 4. Handle speak — block while user is speaking
   if (attemptedAction === 'speak') {
+    if (serverAudioState.isUserSpeaking) {
+      return (async () => {
+        debugLog('[Pre-Speak Hook] User is speaking — waiting for silence before approving speak...');
+        const POLL_INTERVAL_MS = 100;
+        const MAX_WAIT_MS = 10000; // 10 second safety timeout
+        const startTime = Date.now();
+        while (serverAudioState.isUserSpeaking && (Date.now() - startTime) < MAX_WAIT_MS) {
+          await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
+        }
+        if (serverAudioState.isUserSpeaking) {
+          debugLog('[Pre-Speak Hook] Timed out waiting for user to stop speaking — approving anyway');
+        } else {
+          debugLog(`[Pre-Speak Hook] User stopped speaking after ${Date.now() - startTime}ms — approving speak`);
+        }
+        return { decision: 'approve' as const };
+      })();
+    }
     return { decision: 'approve' };
   }
 
@@ -1224,7 +1241,7 @@ app.post('/api/hooks/stop', async (req: Request, res: Response) => {
 });
 
 // Pre-speak hook endpoint
-app.post('/api/hooks/pre-speak', (req: Request, res: Response) => {
+app.post('/api/hooks/pre-speak', async (req: Request, res: Response) => {
   logHookRequest(req, 'pre-speak');
   const { key, session } = parseHookRequest(req);
   registerIfFirst(key);
@@ -1233,9 +1250,9 @@ app.post('/api/hooks/pre-speak', (req: Request, res: Response) => {
 
   // Active session: approve and whitelist the text
   if (isActiveKey(key)) {
-    const result = handleHookRequest('speak', session);
+    const result = await handleHookRequest('speak', session);
     // If approved and we have text, add to whitelist
-    if (speakText && (result as any).decision !== 'block') {
+    if (speakText && result.decision !== 'block') {
       addToWhitelist(speakText, key);
     }
     res.json(result);

--- a/src/unified-server.ts
+++ b/src/unified-server.ts
@@ -1648,20 +1648,21 @@ function startRecognizerForClient(client: WsAudioClient): void {
   const repoRoot = path.join(__dirname, '..');
   const recognizer = new SpeechRecognizer(repoRoot);
 
+  // VAD events drive the userSpeaking state (replaces interim-based detection)
+  recognizer.on('vad', (speaking: boolean) => {
+    serverAudioState.setUserSpeaking(speaking);
+  });
+
   recognizer.on('transcript', (result: { type: string; text: string }) => {
     if (client.ws.readyState !== WebSocket.OPEN) return;
 
     if (result.type === 'interim') {
-      // Signal that user is speaking — blocks TTS queue processing
-      serverAudioState.setUserSpeaking(true);
       client.ws.send(JSON.stringify({
         type: 'transcript-interim',
         text: result.text,
       }));
     } else if (result.type === 'final') {
-      // User finished speaking — release TTS block after debounce
-      serverAudioState.setUserSpeaking(false);
-      if (!result.text.trim()) return; // Empty final — just clear speaking state
+      if (!result.text.trim()) return; // Empty final — skip
       const utteranceId = randomUUID();
       // Create utterance in the selected session (from WS client), falling back to active
       const selectedKey = (client as any).selectedSessionKey;

--- a/src/unified-server.ts
+++ b/src/unified-server.ts
@@ -421,13 +421,20 @@ class ServerAudioState {
         this.onUserSpeakingChange?.(true);
       }
     } else {
-      // User stopped speaking — no debounce needed, the browser worklet
-      // already applies 800ms of silence before sending a stop event
-      if (this._userSpeaking) {
-        debugLog('[ServerAudio] userSpeaking = false');
-        this._userSpeaking = false;
-        this.onUserSpeakingChange?.(false);
+      // User stopped speaking — debounce 500ms as safety buffer.
+      // The worklet already applies 1.5s silence detection, but the server
+      // needs a buffer to avoid race conditions with pre-speak hook checks.
+      if (this._userSpeakingDebounceTimer) {
+        clearTimeout(this._userSpeakingDebounceTimer);
       }
+      this._userSpeakingDebounceTimer = setTimeout(() => {
+        this._userSpeakingDebounceTimer = null;
+        if (this._userSpeaking) {
+          debugLog('[ServerAudio] userSpeaking = false (debounced 500ms)');
+          this._userSpeaking = false;
+          this.onUserSpeakingChange?.(false);
+        }
+      }, 500);
     }
     this.syncState();
   }

--- a/src/unified-server.ts
+++ b/src/unified-server.ts
@@ -1029,22 +1029,46 @@ function handleHookRequest(attemptedAction: 'tool' | 'speak' | 'stop' | 'post-to
     return { decision: 'approve' };
   }
 
-  // 4. Handle speak — block while user is speaking
+  // 4. Handle speak — block while user is speaking, then check for finalized text
   if (attemptedAction === 'speak') {
     if (serverAudioState.isUserSpeaking) {
       return (async () => {
-        debugLog('[Pre-Speak Hook] User is speaking — waiting for silence before approving speak...');
+        debugLog('[Pre-Speak Hook] User is speaking — waiting for speech to finish...');
         const POLL_INTERVAL_MS = 100;
         const MAX_WAIT_MS = 10000; // 10 second safety timeout
+        const GRACE_PERIOD_MS = 500; // wait for finalized text after speech stops
         const startTime = Date.now();
+
+        // Wait for user to stop speaking
         while (serverAudioState.isUserSpeaking && (Date.now() - startTime) < MAX_WAIT_MS) {
           await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
         }
+
         if (serverAudioState.isUserSpeaking) {
           debugLog('[Pre-Speak Hook] Timed out waiting for user to stop speaking — approving anyway');
-        } else {
-          debugLog(`[Pre-Speak Hook] User stopped speaking after ${Date.now() - startTime}ms — approving speak`);
+          return { decision: 'approve' as const };
         }
+
+        // User stopped speaking — grace period to wait for finalized text
+        debugLog(`[Pre-Speak Hook] User stopped speaking after ${Date.now() - startTime}ms — waiting ${GRACE_PERIOD_MS}ms for finalized text...`);
+        await new Promise(resolve => setTimeout(resolve, GRACE_PERIOD_MS));
+
+        // Check if finalized utterances arrived during speech + grace period
+        const pendingNow = s.queue.utterances.filter(u => u.status === 'pending');
+        if (pendingNow.length > 0) {
+          const dequeueResult = dequeueUtterancesCore(s);
+          if (dequeueResult.success && dequeueResult.utterances && dequeueResult.utterances.length > 0) {
+            const reversedUtterances = dequeueResult.utterances.reverse();
+            debugLog(`[Pre-Speak Hook] Finalized text arrived — blocking with ${reversedUtterances.length} utterance(s)`);
+            return {
+              decision: 'block' as const,
+              reason: formatVoiceUtterances(reversedUtterances)
+            };
+          }
+        }
+
+        // No finalized text — false alarm, approve speak
+        debugLog('[Pre-Speak Hook] No finalized text after grace period — approving speak');
         return { decision: 'approve' as const };
       })();
     }

--- a/src/unified-server.ts
+++ b/src/unified-server.ts
@@ -1666,21 +1666,29 @@ function startRecognizerForClient(client: WsAudioClient): void {
   const repoRoot = path.join(__dirname, '..');
   const recognizer = new SpeechRecognizer(repoRoot);
 
-  // VAD events drive the userSpeaking state (replaces interim-based detection)
+  // VAD events supplement interim-based detection
   recognizer.on('vad', (speaking: boolean) => {
-    serverAudioState.setUserSpeaking(speaking);
+    if (speaking) {
+      serverAudioState.setUserSpeaking(true);
+    }
+    // Don't clear on VAD false — let the final transcript or silence timeout handle that
+    debugLog(`[SpeechRecognizer] VAD event: speaking=${speaking}`);
   });
 
   recognizer.on('transcript', (result: { type: string; text: string }) => {
     if (client.ws.readyState !== WebSocket.OPEN) return;
 
     if (result.type === 'interim') {
+      // Interim results also signal user is speaking
+      serverAudioState.setUserSpeaking(true);
       client.ws.send(JSON.stringify({
         type: 'transcript-interim',
         text: result.text,
       }));
     } else if (result.type === 'final') {
-      if (!result.text.trim()) return; // Empty final — skip
+      // Final result — user stopped speaking
+      serverAudioState.setUserSpeaking(false);
+      if (!result.text.trim()) return; // Empty final — just clear speaking state
       const utteranceId = randomUUID();
       // Create utterance in the selected session (from WS client), falling back to active
       const selectedKey = (client as any).selectedSessionKey;

--- a/src/unified-server.ts
+++ b/src/unified-server.ts
@@ -421,8 +421,9 @@ class ServerAudioState {
       // User started speaking — set immediately
       if (!this._userSpeaking) {
         debugLog('[ServerAudio] userSpeaking = true');
+        this._userSpeaking = true;
+        this.onUserSpeakingChange?.(true);
       }
-      this._userSpeaking = true;
       // Reset silence timeout (2 seconds from last speech activity)
       this._resetSilenceTimeout();
     } else {
@@ -433,6 +434,7 @@ class ServerAudioState {
           debugLog('[ServerAudio] userSpeaking = false (debounced)');
           this._userSpeaking = false;
           this._clearSilenceTimeout();
+          this.onUserSpeakingChange?.(false);
           // Resume TTS queue now that user has stopped speaking
           processTtsQueue();
         }
@@ -449,6 +451,7 @@ class ServerAudioState {
       if (this._userSpeaking) {
         debugLog('[ServerAudio] userSpeaking = false (silence timeout)');
         this._userSpeaking = false;
+        this.onUserSpeakingChange?.(false);
         this.syncState();
         // Resume TTS queue
         processTtsQueue();
@@ -466,6 +469,9 @@ class ServerAudioState {
   // Callback for broadcasting state changes to SSE clients.
   // Set after ttsClients is initialised (see broadcastVoiceState helper).
   onStateChange: ((state: string) => void) | null = null;
+
+  // Callback for broadcasting userSpeaking changes to SSE clients.
+  onUserSpeakingChange: ((speaking: boolean) => void) | null = null;
 
   private _transition(newState: typeof this.state): void {
     const oldState = this.state;
@@ -1474,8 +1480,20 @@ function broadcastVoiceState(state: string): void {
   });
 }
 
-// Wire up the ServerAudioState callback now that ttsClients exists
+// Wire up the ServerAudioState callbacks now that ttsClients exists
 serverAudioState.onStateChange = broadcastVoiceState;
+serverAudioState.onUserSpeakingChange = (speaking: boolean) => {
+  const message = JSON.stringify({
+    type: 'user-speaking',
+    speaking,
+    sessionKey: activeCompositeKey
+  });
+  ttsClients.forEach((viewingKey, client) => {
+    if (viewingKey === null || viewingKey === activeCompositeKey) {
+      client.write(`data: ${message}\n\n`);
+    }
+  });
+};
 
 
 // ── WebSocket audio endpoint ──────────────────────────────────────────

--- a/src/unified-server.ts
+++ b/src/unified-server.ts
@@ -421,7 +421,7 @@ class ServerAudioState {
         this.onUserSpeakingChange?.(true);
       }
     } else {
-      // User stopped speaking — debounce 500ms as safety buffer.
+      // User stopped speaking — debounce 1s as safety buffer.
       // The worklet already applies 1.5s silence detection, but the server
       // needs a buffer to avoid race conditions with pre-speak hook checks.
       if (this._userSpeakingDebounceTimer) {
@@ -430,11 +430,11 @@ class ServerAudioState {
       this._userSpeakingDebounceTimer = setTimeout(() => {
         this._userSpeakingDebounceTimer = null;
         if (this._userSpeaking) {
-          debugLog('[ServerAudio] userSpeaking = false (debounced 500ms)');
+          debugLog('[ServerAudio] userSpeaking = false (debounced 1s)');
           this._userSpeaking = false;
           this.onUserSpeakingChange?.(false);
         }
-      }, 500);
+      }, 1000);
     }
     this.syncState();
   }

--- a/src/unified-server.ts
+++ b/src/unified-server.ts
@@ -1044,7 +1044,13 @@ function handleHookRequest(attemptedAction: 'tool' | 'speak' | 'stop' | 'post-to
         }
 
         if (serverAudioState.isUserSpeaking) {
-          debugLog('[Pre-Speak Hook] Timed out waiting for user to stop speaking — approving anyway');
+          debugLog('[Pre-Speak Hook] Timed out waiting for user to stop speaking — checking for utterances before approving');
+          // Even on timeout, check if utterances arrived during the wait
+          const timedOutBlock = dequeueAndBlock(s);
+          if (timedOutBlock) {
+            debugLog('[Pre-Speak Hook] Found utterances after timeout — blocking');
+            return timedOutBlock;
+          }
           return { decision: 'approve' as const };
         }
 
@@ -1652,9 +1658,10 @@ function startRecognizerForClient(client: WsAudioClient): void {
         type: 'transcript-interim',
         text: result.text,
       }));
-    } else if (result.type === 'final' && result.text.trim()) {
+    } else if (result.type === 'final') {
       // User finished speaking — release TTS block after debounce
       serverAudioState.setUserSpeaking(false);
+      if (!result.text.trim()) return; // Empty final — just clear speaking state
       const utteranceId = randomUUID();
       // Create utterance in the selected session (from WS client), falling back to active
       const selectedKey = (client as any).selectedSessionKey;
@@ -1673,12 +1680,14 @@ function startRecognizerForClient(client: WsAudioClient): void {
 
   recognizer.on('error', (err: Error) => {
     debugLog(`[SpeechRecognizer] Error: ${err.message}`);
+    serverAudioState.setUserSpeaking(false); // Clear speaking state on error
     if (client.ws.readyState === WebSocket.OPEN) {
       client.ws.send(JSON.stringify({ type: 'error', message: `Speech recognition error: ${err.message}` }));
     }
   });
 
   recognizer.on('exit', (_code: number | null, _signal: string | null) => {
+    serverAudioState.setUserSpeaking(false); // Clear speaking state on exit
     // If the client is still capturing and recognizer crashed, it will auto-restart
     // via the SpeechRecognizer class. We just need to re-assign when it restarts.
   });

--- a/src/unified-server.ts
+++ b/src/unified-server.ts
@@ -985,28 +985,27 @@ app.post('/api/validate-action', (req: Request, res: Response) => {
 });
 
 // Unified hook handler
+// Dequeue pending utterances and return a block response if any exist.
+// Returns null if no pending utterances.
+function dequeueAndBlock(s: SessionState): { decision: 'block', reason: string } | null {
+  const pending = s.queue.utterances.filter(u => u.status === 'pending');
+  if (pending.length === 0) return null;
+
+  const result = dequeueUtterancesCore(s);
+  if (result.success && result.utterances && result.utterances.length > 0) {
+    const reversed = result.utterances.reverse();
+    return { decision: 'block', reason: formatVoiceUtterances(reversed) };
+  }
+  return null;
+}
+
 function handleHookRequest(attemptedAction: 'tool' | 'speak' | 'stop' | 'post-tool', session?: SessionState): { decision: 'approve' | 'block', reason?: string } | Promise<{ decision: 'approve' | 'block', reason?: string }> {
   const s = session || getActiveSessionOrFirst();
   const voiceActive = voicePreferences.voiceActive;
 
   // 1. Check for pending utterances and auto-dequeue
-  // Always check for pending utterances regardless of voiceActive
-  // This allows typed messages to be dequeued even when mic is off
-  const pendingUtterances = s.queue.utterances.filter(u => u.status === 'pending');
-  if (pendingUtterances.length > 0) {
-    // Always dequeue (dequeueUtterancesCore no longer requires voiceActive)
-    const dequeueResult = dequeueUtterancesCore(s);
-
-    if (dequeueResult.success && dequeueResult.utterances && dequeueResult.utterances.length > 0) {
-      // Reverse to show oldest first
-      const reversedUtterances = dequeueResult.utterances.reverse();
-
-      return {
-        decision: 'block',
-        reason: formatVoiceUtterances(reversedUtterances)
-      };
-    }
-  }
+  const blocked = dequeueAndBlock(s);
+  if (blocked) return blocked;
 
   // 2. Check for delivered utterances (when voice enabled)
   if (voiceActive) {
@@ -1054,17 +1053,10 @@ function handleHookRequest(attemptedAction: 'tool' | 'speak' | 'stop' | 'post-to
         await new Promise(resolve => setTimeout(resolve, GRACE_PERIOD_MS));
 
         // Check if finalized utterances arrived during speech + grace period
-        const pendingNow = s.queue.utterances.filter(u => u.status === 'pending');
-        if (pendingNow.length > 0) {
-          const dequeueResult = dequeueUtterancesCore(s);
-          if (dequeueResult.success && dequeueResult.utterances && dequeueResult.utterances.length > 0) {
-            const reversedUtterances = dequeueResult.utterances.reverse();
-            debugLog(`[Pre-Speak Hook] Finalized text arrived — blocking with ${reversedUtterances.length} utterance(s)`);
-            return {
-              decision: 'block' as const,
-              reason: formatVoiceUtterances(reversedUtterances)
-            };
-          }
+        const blocked = dequeueAndBlock(s);
+        if (blocked) {
+          debugLog(`[Pre-Speak Hook] Finalized text arrived — blocking with utterances`);
+          return blocked;
         }
 
         // No finalized text — false alarm, approve speak

--- a/src/unified-server.ts
+++ b/src/unified-server.ts
@@ -421,15 +421,13 @@ class ServerAudioState {
         this.onUserSpeakingChange?.(true);
       }
     } else {
-      // User stopped speaking — debounce 300ms to absorb gaps between words
-      this._userSpeakingDebounceTimer = setTimeout(() => {
-        this._userSpeakingDebounceTimer = null;
-        if (this._userSpeaking) {
-          debugLog('[ServerAudio] userSpeaking = false (debounced)');
-          this._userSpeaking = false;
-          this.onUserSpeakingChange?.(false);
-        }
-      }, 300);
+      // User stopped speaking — no debounce needed, the browser worklet
+      // already applies 800ms of silence before sending a stop event
+      if (this._userSpeaking) {
+        debugLog('[ServerAudio] userSpeaking = false');
+        this._userSpeaking = false;
+        this.onUserSpeakingChange?.(false);
+      }
     }
     this.syncState();
   }

--- a/src/unified-server.ts
+++ b/src/unified-server.ts
@@ -1646,6 +1646,16 @@ function handleWsControlMessage(client: WsAudioClient, msg: { type: string; [key
       break;
     }
 
+    case 'user-speaking-start':
+      serverAudioState.setUserSpeaking(true);
+      debugLog('[WS] Browser VAD: user speaking start');
+      break;
+
+    case 'user-speaking-stop':
+      serverAudioState.setUserSpeaking(false);
+      debugLog('[WS] Browser VAD: user speaking stop');
+      break;
+
     case 'ping':
       client.ws.send(JSON.stringify({ type: 'pong' }));
       break;

--- a/src/unified-server.ts
+++ b/src/unified-server.ts
@@ -411,10 +411,6 @@ class ServerAudioState {
 
     if (active) {
       // User started speaking — set immediately
-      if (this._userSpeakingDebounceTimer) {
-        clearTimeout(this._userSpeakingDebounceTimer);
-        this._userSpeakingDebounceTimer = null;
-      }
       if (!this._userSpeaking) {
         debugLog('[ServerAudio] userSpeaking = true');
         this._userSpeaking = true;
@@ -1020,43 +1016,46 @@ function handleHookRequest(attemptedAction: 'tool' | 'speak' | 'stop' | 'post-to
         const GRACE_PERIOD_MS = 2000; // wait for finalized text after speech stops
         const startTime = Date.now();
 
-        // Wait for user to stop speaking
-        while (serverAudioState.isUserSpeaking && (Date.now() - startTime) < MAX_WAIT_MS) {
-          await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
-        }
-
-        if (serverAudioState.isUserSpeaking) {
-          debugLog('[Pre-Speak Hook] Timed out waiting for user to stop speaking — checking for utterances before approving');
-          // Even on timeout, check if utterances arrived during the wait
-          const timedOutBlock = dequeueAndBlock(s);
-          if (timedOutBlock) {
-            debugLog('[Pre-Speak Hook] Found utterances after timeout — blocking');
-            return timedOutBlock;
+        // Outer loop: handles user resuming speech during grace period
+        // by going back to wait-for-silence → grace-period cycle
+        while ((Date.now() - startTime) < MAX_WAIT_MS) {
+          // Wait for user to stop speaking
+          while (serverAudioState.isUserSpeaking && (Date.now() - startTime) < MAX_WAIT_MS) {
+            await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
           }
-          return { decision: 'approve' as const };
-        }
 
-        // User stopped speaking — poll for finalized text during grace period
-        debugLog(`[Pre-Speak Hook] User stopped speaking after ${Date.now() - startTime}ms — polling ${GRACE_PERIOD_MS}ms for finalized text...`);
-        const graceStart = Date.now();
-        while ((Date.now() - graceStart) < GRACE_PERIOD_MS) {
-          // Check for pending utterances on each poll
-          const blocked = dequeueAndBlock(s);
-          if (blocked) {
-            debugLog(`[Pre-Speak Hook] Finalized text arrived during grace period — blocking with utterances`);
-            return blocked;
-          }
-          // Also check if user started speaking again
           if (serverAudioState.isUserSpeaking) {
-            debugLog('[Pre-Speak Hook] User started speaking again during grace period — resuming wait');
-            // Go back to waiting for speech to finish
-            while (serverAudioState.isUserSpeaking && (Date.now() - startTime) < MAX_WAIT_MS) {
-              await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
+            debugLog('[Pre-Speak Hook] Timed out waiting for user to stop speaking — checking for utterances before approving');
+            const timedOutBlock = dequeueAndBlock(s);
+            if (timedOutBlock) {
+              debugLog('[Pre-Speak Hook] Found utterances after timeout — blocking');
+              return timedOutBlock;
             }
-            // Reset grace period
-            break;
+            return { decision: 'approve' as const };
           }
-          await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
+
+          // User stopped speaking — poll for finalized text during grace period
+          debugLog(`[Pre-Speak Hook] User stopped speaking after ${Date.now() - startTime}ms — polling ${GRACE_PERIOD_MS}ms for finalized text...`);
+          const graceStart = Date.now();
+          let userResumedSpeaking = false;
+
+          while ((Date.now() - graceStart) < GRACE_PERIOD_MS && (Date.now() - startTime) < MAX_WAIT_MS) {
+            const blocked = dequeueAndBlock(s);
+            if (blocked) {
+              debugLog(`[Pre-Speak Hook] Finalized text arrived during grace period — blocking with utterances`);
+              return blocked;
+            }
+            // If user starts speaking again, restart the whole cycle
+            if (serverAudioState.isUserSpeaking) {
+              debugLog('[Pre-Speak Hook] User started speaking again during grace period — restarting wait cycle');
+              userResumedSpeaking = true;
+              break;
+            }
+            await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
+          }
+
+          // If user didn't resume, grace period completed — do final check and exit
+          if (!userResumedSpeaking) break;
         }
 
         // Final check after grace period
@@ -1691,9 +1690,12 @@ function startRecognizerForClient(client: WsAudioClient): void {
         text: result.text,
       }));
     } else if (result.type === 'final') {
-      // Final result — user stopped speaking
-      serverAudioState.setUserSpeaking(false);
-      if (!result.text.trim()) return; // Empty final — just clear speaking state
+      // NOTE: Do NOT call setUserSpeaking(false) here. A "final" transcript means a
+      // segment was finalized by the recognizer, but the user may still be mid-thought
+      // (e.g., "Please fix the bug" finalizes while they continue "...in the login page").
+      // Rely on the browser worklet VAD (audio-level silence detection) as the sole
+      // authority for when the user actually stops speaking.
+      if (!result.text.trim()) return; // Empty final — ignore
       const utteranceId = randomUUID();
       // Create utterance in the selected session (from WS client), falling back to active
       const selectedKey = (client as any).selectedSessionKey;

--- a/src/unified-server.ts
+++ b/src/unified-server.ts
@@ -63,18 +63,11 @@ function waitForTtsAck(audioId: string): Promise<void> {
 }
 
 async function processTtsQueue() {
-  if (ttsPlaying || ttsQueue.length === 0 || serverAudioState.isUserSpeaking) return;
+  if (ttsPlaying || ttsQueue.length === 0) return;
   ttsPlaying = true;
   const item = ttsQueue.shift()!;
   try {
     const { audioId, filePath } = await renderTtsToFile(item.text, item.rate);
-    // If user started speaking during render, re-enqueue and defer
-    if (serverAudioState.isUserSpeaking) {
-      debugLog(`[TTS] User started speaking during render — re-enqueueing`);
-      ttsQueue.unshift(item);
-      ttsPlaying = false;
-      return;
-    }
     // Check if a WS client is connected for this session — prefer WS delivery
     const targetKey = item.sessionKey || activeCompositeKey;
     const wsClient = findWsClientForSession(targetKey);
@@ -435,8 +428,6 @@ class ServerAudioState {
           debugLog('[ServerAudio] userSpeaking = false (debounced)');
           this._userSpeaking = false;
           this.onUserSpeakingChange?.(false);
-          // Resume TTS queue now that user has stopped speaking
-          processTtsQueue();
         }
       }, 300);
     }

--- a/src/unified-server.ts
+++ b/src/unified-server.ts
@@ -63,11 +63,18 @@ function waitForTtsAck(audioId: string): Promise<void> {
 }
 
 async function processTtsQueue() {
-  if (ttsPlaying || ttsQueue.length === 0) return;
+  if (ttsPlaying || ttsQueue.length === 0 || serverAudioState.isUserSpeaking) return;
   ttsPlaying = true;
   const item = ttsQueue.shift()!;
   try {
     const { audioId, filePath } = await renderTtsToFile(item.text, item.rate);
+    // If user started speaking during render, re-enqueue and defer
+    if (serverAudioState.isUserSpeaking) {
+      debugLog(`[TTS] User started speaking during render — re-enqueueing`);
+      ttsQueue.unshift(item);
+      ttsPlaying = false;
+      return;
+    }
     // Check if a WS client is connected for this session — prefer WS delivery
     const targetKey = item.sessionKey || activeCompositeKey;
     const wsClient = findWsClientForSession(targetKey);
@@ -339,6 +346,9 @@ class ServerAudioState {
   private _lastWaitStatus = false;
   private _ttsActive = false;
   private _hookActive = false;
+  private _userSpeaking = false;
+  private _userSpeakingDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private _userSpeakingSilenceTimer: ReturnType<typeof setTimeout> | null = null;
   private _pulseTimer: ReturnType<typeof setInterval> | null = null;
 
   syncState(): void {
@@ -394,6 +404,63 @@ class ServerAudioState {
   setTtsActive(active: boolean): void {
     this._ttsActive = active;
     this.syncState();
+  }
+
+  get isUserSpeaking(): boolean {
+    return this._userSpeaking;
+  }
+
+  setUserSpeaking(active: boolean): void {
+    // Clear any pending debounce timer
+    if (this._userSpeakingDebounceTimer) {
+      clearTimeout(this._userSpeakingDebounceTimer);
+      this._userSpeakingDebounceTimer = null;
+    }
+
+    if (active) {
+      // User started speaking — set immediately
+      if (!this._userSpeaking) {
+        debugLog('[ServerAudio] userSpeaking = true');
+      }
+      this._userSpeaking = true;
+      // Reset silence timeout (2 seconds from last speech activity)
+      this._resetSilenceTimeout();
+    } else {
+      // User stopped speaking — debounce 300ms to absorb gaps between words
+      this._userSpeakingDebounceTimer = setTimeout(() => {
+        this._userSpeakingDebounceTimer = null;
+        if (this._userSpeaking) {
+          debugLog('[ServerAudio] userSpeaking = false (debounced)');
+          this._userSpeaking = false;
+          this._clearSilenceTimeout();
+          // Resume TTS queue now that user has stopped speaking
+          processTtsQueue();
+        }
+      }, 300);
+    }
+    this.syncState();
+  }
+
+  private _resetSilenceTimeout(): void {
+    this._clearSilenceTimeout();
+    // If no transcript events arrive within 2 seconds, assume user stopped speaking
+    this._userSpeakingSilenceTimer = setTimeout(() => {
+      this._userSpeakingSilenceTimer = null;
+      if (this._userSpeaking) {
+        debugLog('[ServerAudio] userSpeaking = false (silence timeout)');
+        this._userSpeaking = false;
+        this.syncState();
+        // Resume TTS queue
+        processTtsQueue();
+      }
+    }, 2000);
+  }
+
+  private _clearSilenceTimeout(): void {
+    if (this._userSpeakingSilenceTimer) {
+      clearTimeout(this._userSpeakingSilenceTimer);
+      this._userSpeakingSilenceTimer = null;
+    }
   }
 
   // Callback for broadcasting state changes to SSE clients.
@@ -1522,6 +1589,14 @@ function handleWsControlMessage(client: WsAudioClient, msg: { type: string; [key
       break;
     }
 
+    case 'user-speaking-start':
+      serverAudioState.setUserSpeaking(true);
+      break;
+
+    case 'user-speaking-stop':
+      serverAudioState.setUserSpeaking(false);
+      break;
+
     case 'ping':
       client.ws.send(JSON.stringify({ type: 'pong' }));
       break;
@@ -1546,11 +1621,15 @@ function startRecognizerForClient(client: WsAudioClient): void {
     if (client.ws.readyState !== WebSocket.OPEN) return;
 
     if (result.type === 'interim') {
+      // Signal that user is speaking — blocks TTS queue processing
+      serverAudioState.setUserSpeaking(true);
       client.ws.send(JSON.stringify({
         type: 'transcript-interim',
         text: result.text,
       }));
     } else if (result.type === 'final' && result.text.trim()) {
+      // User finished speaking — release TTS block after debounce
+      serverAudioState.setUserSpeaking(false);
       const utteranceId = randomUUID();
       // Create utterance in the selected session (from WS client), falling back to active
       const selectedKey = (client as any).selectedSessionKey;

--- a/src/unified-server.ts
+++ b/src/unified-server.ts
@@ -1017,7 +1017,7 @@ function handleHookRequest(attemptedAction: 'tool' | 'speak' | 'stop' | 'post-to
         debugLog('[Pre-Speak Hook] User is speaking — waiting for speech to finish...');
         const POLL_INTERVAL_MS = 100;
         const MAX_WAIT_MS = 10000; // 10 second safety timeout
-        const GRACE_PERIOD_MS = 500; // wait for finalized text after speech stops
+        const GRACE_PERIOD_MS = 2000; // wait for finalized text after speech stops
         const startTime = Date.now();
 
         // Wait for user to stop speaking
@@ -1036,15 +1036,34 @@ function handleHookRequest(attemptedAction: 'tool' | 'speak' | 'stop' | 'post-to
           return { decision: 'approve' as const };
         }
 
-        // User stopped speaking — grace period to wait for finalized text
-        debugLog(`[Pre-Speak Hook] User stopped speaking after ${Date.now() - startTime}ms — waiting ${GRACE_PERIOD_MS}ms for finalized text...`);
-        await new Promise(resolve => setTimeout(resolve, GRACE_PERIOD_MS));
+        // User stopped speaking — poll for finalized text during grace period
+        debugLog(`[Pre-Speak Hook] User stopped speaking after ${Date.now() - startTime}ms — polling ${GRACE_PERIOD_MS}ms for finalized text...`);
+        const graceStart = Date.now();
+        while ((Date.now() - graceStart) < GRACE_PERIOD_MS) {
+          // Check for pending utterances on each poll
+          const blocked = dequeueAndBlock(s);
+          if (blocked) {
+            debugLog(`[Pre-Speak Hook] Finalized text arrived during grace period — blocking with utterances`);
+            return blocked;
+          }
+          // Also check if user started speaking again
+          if (serverAudioState.isUserSpeaking) {
+            debugLog('[Pre-Speak Hook] User started speaking again during grace period — resuming wait');
+            // Go back to waiting for speech to finish
+            while (serverAudioState.isUserSpeaking && (Date.now() - startTime) < MAX_WAIT_MS) {
+              await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
+            }
+            // Reset grace period
+            break;
+          }
+          await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
+        }
 
-        // Check if finalized utterances arrived during speech + grace period
-        const blocked = dequeueAndBlock(s);
-        if (blocked) {
+        // Final check after grace period
+        const finalBlocked = dequeueAndBlock(s);
+        if (finalBlocked) {
           debugLog(`[Pre-Speak Hook] Finalized text arrived — blocking with utterances`);
-          return blocked;
+          return finalBlocked;
         }
 
         // No finalized text — false alarm, approve speak

--- a/swift/speech-recognizer/Sources/SpeechRecognizer/main.swift
+++ b/swift/speech-recognizer/Sources/SpeechRecognizer/main.swift
@@ -98,8 +98,11 @@ func runSpeechRecognizer() async throws {
         attributeOptions: []
     )
 
-    // Get the best available audio format for the transcriber
-    guard let targetFormat = await SpeechAnalyzer.bestAvailableAudioFormat(compatibleWith: [transcriber]) else {
+    // Create speech detector for voice activity detection
+    let detector = SpeechDetector()
+
+    // Get the best available audio format for both modules
+    guard let targetFormat = await SpeechAnalyzer.bestAvailableAudioFormat(compatibleWith: [transcriber, detector]) else {
         fputs("[speech-recognizer] ERROR: No compatible audio format available. The speech model may not be installed.\n", stderr)
         fputs("[speech-recognizer] Try using Dictation in System Settings first to trigger model download.\n", stderr)
         exit(1)
@@ -107,8 +110,8 @@ func runSpeechRecognizer() async throws {
 
     fputs("[speech-recognizer] Target format: \(targetFormat)\n", stderr)
 
-    // Create analyzer and input stream
-    let analyzer = SpeechAnalyzer(modules: [transcriber])
+    // Create analyzer with both transcriber and detector
+    let analyzer = SpeechAnalyzer(modules: [transcriber, detector])
     let inputStream = makeAnalyzerInputStream(from: audioSource.stream, targetFormat: targetFormat)
 
     // Run everything concurrently
@@ -129,7 +132,7 @@ func runSpeechRecognizer() async throws {
 
         // Process transcription results
         group.addTask {
-            fputs("[speech-recognizer] Waiting for results...\n", stderr)
+            fputs("[speech-recognizer] Waiting for transcription results...\n", stderr)
             do {
                 for try await result in transcriber.results {
                     let text = String(result.text.characters)
@@ -144,7 +147,21 @@ func runSpeechRecognizer() async throws {
             } catch {
                 fputs("[speech-recognizer] Transcription error: \(error.localizedDescription)\n", stderr)
             }
-            fputs("[speech-recognizer] Results stream ended.\n", stderr)
+            fputs("[speech-recognizer] Transcription stream ended.\n", stderr)
+        }
+
+        // Process voice activity detection results
+        group.addTask {
+            fputs("[speech-recognizer] Waiting for VAD results...\n", stderr)
+            do {
+                for try await _ in detector.results {
+                    writeJSON(["type": "vad", "speaking": "true"])
+                }
+            } catch {
+                fputs("[speech-recognizer] VAD error: \(error.localizedDescription)\n", stderr)
+            }
+            writeJSON(["type": "vad", "speaking": "false"])
+            fputs("[speech-recognizer] VAD stream ended.\n", stderr)
         }
 
         await group.waitForAll()


### PR DESCRIPTION
## Summary

- Adds _userSpeaking boolean flag to ServerAudioState that gates TTS queue processing
- Pre-speak hook blocks while user is speaking, polls isUserSpeaking state and waits (up to 10s) for silence before approving
- Browser worklet VAD for instant audio-level speech detection
- Server-side debounce and grace period for robust interruption prevention

### Threshold tuning (latest commit)

Three root causes of TTS slipping through gaps and indicator flickering identified and fixed:

1. **Final transcript events no longer clear speaking state** - A final transcript from the recognizer does not mean the user stopped talking, just that a segment was finalized. Now only the browser worklet VAD (audio-level silence detection) controls when the user is considered to have stopped speaking.
2. **Grace period restart bug fixed** - When user resumed speaking during the grace period, the old code broke out of the loop without restarting the grace period, potentially approving TTS too early. Restructured as an outer loop that properly cycles between wait-for-silence and grace-period phases.
3. **Frontend indicator hide timer increased** from 1s to 2s to prevent flickering during natural inter-sentence pauses.

## Test plan

- [x] Build passes
- [x] All 221 tests pass
- [ ] Manual test: speak while Claude is responding - TTS should defer until user stops
- [ ] Manual test: verify TTS resumes promptly after user stops speaking
- [ ] Manual test: verify indicator no longer flickers between words
- [ ] Manual test: verify multi-sentence speech does not trigger premature TTS