### PR TITLE
docs: add known limitation for background agents in voice mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ There is a bug in Safari that prevents browser text-to-speech from loading high-
 
 ## Known Limitations
 
-- **Background agents don't notify in voice mode.** When Claude launches background agents (subprocesses), their completion notifications appear in the conversation text but don't trigger hooks. This means you won't hear a voice notification when a background task finishes. **Workaround:** Manually check background agent status, or avoid using background agents during voice sessions.
+- **Background agents don't notify in voice mode.** When Claude launches background agents (via the Agent tool), their completion notifications appear in the conversation text but don't trigger hooks. This means you won't hear a voice notification when a background task finishes. **Workaround:** Manually check background agent status, or avoid using background agents during voice sessions. *(Verified with Claude Code 2.1.69, March 2026)*
 
 ## Uninstallation
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ Other downloaded voices will show up in the voice dropdown in the voice-hooks br
 
 There is a bug in Safari that prevents browser text-to-speech from loading high-quality voices after browser restart. This is a Safari Web Speech API limitation. To use high-quality voices in Safari you need to set your system voice to Siri and select "Mac System Voice" in the voice-hooks browser interface.
 
+## Known Limitations
+
+- **Background agents don't notify in voice mode.** When Claude launches background agents (subprocesses), their completion notifications appear in the conversation text but don't trigger hooks. This means you won't hear a voice notification when a background task finishes. **Workaround:** Manually check background agent status, or avoid using background agents during voice sessions.
+
 ## Uninstallation
 
 Remove the `extraKnownMarketplaces` and `enabledPlugins` entries from your settings file and restart Claude Code.


### PR DESCRIPTION
## Summary
- Adds a "Known Limitations" section to the README documenting that background agents (subprocesses) complete silently without triggering hooks in voice mode
- Users won't hear voice notifications for completed background tasks; workaround is to check status manually or avoid background agents during voice sessions

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm the new section appears before Uninstallation

🤖 Generated with [Claude Code](https://claude.com/claude-code)