### PR TITLE
fix: unify session routing to browser-selected session

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -150,8 +150,8 @@ class MessengerClient {
 
         // Session state
         this.sessions = [];
-        this.activeSessionKey = null;       // Server's active key (for hooks/TTS routing)
-        this.selectedSessionKey = null;     // User's UI selection (which tab they're viewing)
+        this.activeSessionKey = null;       // Server's selected key (for backward compat with API responses)
+        this.selectedSessionKey = null;     // User's UI selection — authoritative for all routing
         this.unreadCounts = {}; // key → count of messages since last viewed
 
         // Initialize

--- a/public/app.js
+++ b/public/app.js
@@ -993,6 +993,10 @@ class MessengerClient {
             console.log('[WS] Connected');
             this.wsConnected = true;
             this.wsReconnectDelay = 1000; // Reset backoff on successful connect
+            // Sync browser's selected session to server on WS connect/reconnect
+            if (this.selectedSessionKey) {
+                this.audioWs.send(JSON.stringify({ type: 'select-session', sessionKey: this.selectedSessionKey }));
+            }
             // Start audio capture now that the WS connection is ready
             this.startAudioCapture();
         };

--- a/src/__tests__/background-enforcement.test.ts
+++ b/src/__tests__/background-enforcement.test.ts
@@ -120,6 +120,13 @@ describe('Background Voice Enforcement', () => {
     });
 
     it('inactive session can stop after speaking when enforcement is on', async () => {
+      // Enable voice responses (required for /api/speak to work)
+      await fetch(`${server.url}/api/voice-active`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ active: true }),
+      });
+
       // Enable enforcement
       await fetch(`${server.url}/api/background-voice-enforcement`, {
         method: 'POST',
@@ -127,7 +134,7 @@ describe('Background Voice Enforcement', () => {
         body: JSON.stringify({ enabled: true }),
       });
 
-      // Register main as active
+      // Register main as selected
       await fetch(`${server.url}/api/hooks/post-tool`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -141,7 +148,7 @@ describe('Background Voice Enforcement', () => {
         body: JSON.stringify({ session_id: 'session1', agent_id: 'agent-1', agent_type: 'explore' }),
       });
 
-      // Sub-agent speaks (pre-speak stores in conversation history for inactive session)
+      // Sub-agent pre-speak whitelists, then speak stores and sets lastSpeakTimestamp
       await fetch(`${server.url}/api/hooks/pre-speak`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -150,6 +157,11 @@ describe('Background Voice Enforcement', () => {
           agent_id: 'agent-1',
           tool_input: { text: 'I found the answer.' },
         }),
+      });
+      await fetch(`${server.url}/api/speak`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: 'I found the answer.' }),
       });
 
       // Sub-agent tries to stop - should be allowed now

--- a/src/__tests__/session-restart.test.ts
+++ b/src/__tests__/session-restart.test.ts
@@ -1,6 +1,6 @@
 import { TestServer } from '../test-utils/test-server.js';
 
-describe('Session restart detection', () => {
+describe('Session selection behavior', () => {
   let server: TestServer;
 
   beforeEach(async () => {
@@ -12,117 +12,17 @@ describe('Session restart detection', () => {
     await server.stop();
   });
 
-  it('resets voice state when a new Claude session_id is detected', async () => {
-    // Simulate first Claude session registering
+  it('first session auto-selects when no session is selected', async () => {
     await fetch(`${server.url}/api/hooks/post-tool`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ session_id: 'session-old' }),
+      body: JSON.stringify({ session_id: 'session-first' }),
     });
-    expect(server.activeCompositeKey).toBe(JSON.stringify(['session-old', 'main']));
-
-    // Browser enables voice
-    await fetch(`${server.url}/api/voice-active`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ active: true }),
-    });
-
-    const prefsBefore = server.getVoicePreferences();
-    expect(prefsBefore.voiceActive).toBe(true);
-
-    // Claude restarts — new session_id arrives via hook
-    await fetch(`${server.url}/api/hooks/post-tool`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ session_id: 'session-new' }),
-    });
-
-    // Active session should switch to the new one
-    expect(server.activeCompositeKey).toBe(JSON.stringify(['session-new', 'main']));
-
-    // Voice state should be reset
-    const prefsAfter = server.getVoicePreferences();
-    expect(prefsAfter.voiceActive).toBe(false);
+    expect(server.selectedSessionKey).toBe(JSON.stringify(['session-first', 'main']));
   });
 
-  it('new session becomes active and hooks work correctly after restart', async () => {
-    // First session registers and enables voice
-    await fetch(`${server.url}/api/hooks/post-tool`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ session_id: 'session-old' }),
-    });
-    await fetch(`${server.url}/api/voice-active`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ active: true }),
-    });
-
-    // Claude restarts with new session
-    await fetch(`${server.url}/api/hooks/post-tool`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ session_id: 'session-new' }),
-    });
-
-    // Browser re-syncs voice state (simulating what syncVoiceStateToServer does)
-    await fetch(`${server.url}/api/voice-active`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ active: true }),
-    });
-
-    // New session should be active and voice should work
-    const prefs = server.getVoicePreferences();
-    expect(prefs.voiceActive).toBe(true);
-
-    // Stop hook on the new session should work as active (not inactive)
-    // Add an utterance so stop hook has something to check
-    await fetch(`${server.url}/api/potential-utterances`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ text: 'Hello new session' }),
-    });
-
-    const stopRes = await fetch(`${server.url}/api/hooks/stop`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ session_id: 'session-new' }),
-    });
-    const stopData = await stopRes.json() as any;
-    // Should block because there are pending utterances — proving the new session is active
-    expect(stopData.decision).toBe('block');
-  });
-
-  it('does not reset when same session_id sends another hook', async () => {
-    // Register session
-    await fetch(`${server.url}/api/hooks/post-tool`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ session_id: 'session-1' }),
-    });
-
-    // Enable voice
-    await fetch(`${server.url}/api/voice-active`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ active: true }),
-    });
-
-    // Same session sends another hook — should NOT reset
-    await fetch(`${server.url}/api/hooks/post-tool`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ session_id: 'session-1' }),
-    });
-
-    const prefs = server.getVoicePreferences();
-    expect(prefs.voiceActive).toBe(true);
-  });
-
-  it('switches active to new session_id even if old session was recently active', async () => {
-    // Register session A
+  it('second session does NOT auto-select (browser must switch)', async () => {
+    // First session auto-selects
     await fetch(`${server.url}/api/hooks/post-tool`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -136,17 +36,74 @@ describe('Session restart detection', () => {
       body: JSON.stringify({ active: true }),
     });
 
-    // Session B arrives immediately — should still switch active and reset voice
+    // Second session arrives — does NOT steal selection
     await fetch(`${server.url}/api/hooks/post-tool`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ session_id: 'session-B' }),
     });
 
-    expect(server.activeCompositeKey).toBe(JSON.stringify(['session-B', 'main']));
+    // Selection stays with session-A
+    expect(server.selectedSessionKey).toBe(JSON.stringify(['session-A', 'main']));
 
+    // Voice state is NOT reset (only browser selection changes routing)
     const prefs = server.getVoicePreferences();
-    expect(prefs.voiceActive).toBe(false);
+    expect(prefs.voiceActive).toBe(true);
+  });
+
+  it('browser can switch selection via /api/active-session', async () => {
+    // Register both sessions
+    await fetch(`${server.url}/api/hooks/post-tool`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ session_id: 'session-A' }),
+    });
+    await fetch(`${server.url}/api/hooks/post-tool`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ session_id: 'session-B' }),
+    });
+
+    // Browser switches to session-B
+    const switchRes = await fetch(`${server.url}/api/active-session`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ key: JSON.stringify(['session-B', 'main']) }),
+    });
+    const switchData = await switchRes.json() as any;
+    expect(switchData.success).toBe(true);
+    expect(server.selectedSessionKey).toBe(JSON.stringify(['session-B', 'main']));
+  });
+
+  it('new session hooks work correctly for the selected session', async () => {
+    // Register session
+    await fetch(`${server.url}/api/hooks/post-tool`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ session_id: 'session-new' }),
+    });
+
+    await fetch(`${server.url}/api/voice-active`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ active: true }),
+    });
+
+    // Add an utterance so stop hook has something to check
+    await fetch(`${server.url}/api/potential-utterances`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: 'Hello new session' }),
+    });
+
+    const stopRes = await fetch(`${server.url}/api/hooks/stop`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ session_id: 'session-new' }),
+    });
+    const stopData = await stopRes.json() as any;
+    // Should block because there are pending utterances — session is selected
+    expect(stopData.decision).toBe('block');
   });
 
   it('does not reset for subagent hooks within the same session', async () => {
@@ -164,7 +121,7 @@ describe('Session restart detection', () => {
       body: JSON.stringify({ active: true }),
     });
 
-    // Subagent from the same session sends hook — should NOT reset
+    // Subagent from the same session sends hook — should NOT change selection
     await fetch(`${server.url}/api/hooks/post-tool`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -173,6 +130,6 @@ describe('Session restart detection', () => {
 
     const prefs = server.getVoicePreferences();
     expect(prefs.voiceActive).toBe(true);
-    expect(server.activeCompositeKey).toBe(JSON.stringify(['session-1', 'main']));
+    expect(server.selectedSessionKey).toBe(JSON.stringify(['session-1', 'main']));
   });
 });

--- a/src/__tests__/session-routing-bugs.test.ts
+++ b/src/__tests__/session-routing-bugs.test.ts
@@ -32,7 +32,7 @@ describe('Session routing bug fixes', () => {
       expect(defaultSession).toBeUndefined();
     });
 
-    it('registerIfFirst upgrades from default to real session', async () => {
+    it('autoSelectIfNone upgrades from default to real session', async () => {
       // First, create a default session by calling a browser endpoint (no hooks yet)
       await fetch(`${server.url}/api/potential-utterances`, {
         method: 'POST',
@@ -49,7 +49,7 @@ describe('Session routing bug fixes', () => {
 
       // The active session should now be the real session, not default
       const realKey = JSON.stringify(['real-session', 'main']);
-      expect(server.activeCompositeKey).toBe(realKey);
+      expect(server.selectedSessionKey).toBe(realKey);
     });
 
     it('default session does not become active when real session already active', async () => {
@@ -61,7 +61,7 @@ describe('Session routing bug fixes', () => {
       });
 
       const realKey = JSON.stringify(['real-session', 'main']);
-      expect(server.activeCompositeKey).toBe(realKey);
+      expect(server.selectedSessionKey).toBe(realKey);
 
       // Call browser endpoints that would previously create/return default session
       await fetch(`${server.url}/api/utterances`);
@@ -69,7 +69,7 @@ describe('Session routing bug fixes', () => {
       await fetch(`${server.url}/api/utterances/status`);
 
       // Active should still be the real session
-      expect(server.activeCompositeKey).toBe(realKey);
+      expect(server.selectedSessionKey).toBe(realKey);
     });
   });
 
@@ -118,7 +118,7 @@ describe('Session routing bug fixes', () => {
         body: JSON.stringify({ text: 'Response from A' }),
       });
 
-      // Subagent speaks (inactive, stored in subagent's history)
+      // Subagent pre-speak whitelists text (all sessions now whitelist)
       await fetch(`${server.url}/api/hooks/pre-speak`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -127,6 +127,13 @@ describe('Session routing bug fixes', () => {
           agent_id: 'subagent-B',
           tool_input: { text: 'Response from B' },
         }),
+      });
+
+      // Subagent speaks — stored in subagent's conversation history via speak endpoint
+      await fetch(`${server.url}/api/speak`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: 'Response from B' }),
       });
 
       // Verify main agent has its messages (user + assistant)

--- a/src/__tests__/session-state.test.ts
+++ b/src/__tests__/session-state.test.ts
@@ -21,7 +21,7 @@ describe('Per-session state and session lifecycle', () => {
       });
       const data = await res.json() as any;
       expect(data.decision).toBe('approve');
-      expect(server.activeCompositeKey).toBe(JSON.stringify(['sess-1', 'main']));
+      expect(server.selectedSessionKey).toBe(JSON.stringify(['sess-1', 'main']));
     });
 
     it('missing session_id defaults to "default"', async () => {
@@ -30,7 +30,7 @@ describe('Per-session state and session lifecycle', () => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({}),
       });
-      expect(server.activeCompositeKey).toBe(JSON.stringify(['default', 'main']));
+      expect(server.selectedSessionKey).toBe(JSON.stringify(['default', 'main']));
     });
   });
 
@@ -79,7 +79,7 @@ describe('Per-session state and session lifecycle', () => {
         body: JSON.stringify({ text: 'Hello from A' }),
       });
 
-      // Register session-B (does NOT become active — registerIfFirst only sets the first)
+      // Register session-B (does NOT become active — autoSelectIfNone only sets the first)
       await fetch(`${server.url}/api/hooks/post-tool`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -100,7 +100,7 @@ describe('Per-session state and session lifecycle', () => {
       expect(sessionB!.queue.utterances.length).toBe(0);
     });
 
-    it('inactive session pre-speak stores message in conversation history', async () => {
+    it('background session pre-speak whitelists text and approves', async () => {
       // Enable voice
       await fetch(`${server.url}/api/voice-active`, {
         method: 'POST',
@@ -108,14 +108,14 @@ describe('Per-session state and session lifecycle', () => {
         body: JSON.stringify({ active: true }),
       });
 
-      // Set main agent as active
+      // Set main agent as selected
       await fetch(`${server.url}/api/hooks/post-tool`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ session_id: 'session-A' }),
       });
 
-      // Subagent tries to speak (inactive, approved but no TTS)
+      // Subagent tries to speak (background session, approved and whitelisted)
       const res = await fetch(`${server.url}/api/hooks/pre-speak`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -128,7 +128,20 @@ describe('Per-session state and session lifecycle', () => {
       const data = await res.json() as any;
       expect(data.decision).toBe('approve');
 
-      // Check the message was stored in subagent-B's conversation history
+      // Text should be whitelisted (all sessions now get whitelisted)
+      expect(server.speakWhitelist.has('I am B')).toBe(true);
+
+      // When speak is called, text gets stored in conversation history
+      // but no TTS audio plays (background session)
+      const speakRes = await fetch(`${server.url}/api/speak`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: 'I am B' }),
+      });
+      const speakData = await speakRes.json() as any;
+      expect(speakData.success).toBe(true);
+
+      // Verify the message was stored in subagent-B's conversation history via speak
       const sessionBKey = JSON.stringify(['session-A', 'subagent-B']);
       const sessionB = server.sessions.get(sessionBKey);
       expect(sessionB).toBeDefined();
@@ -171,8 +184,15 @@ describe('Per-session state and session lifecycle', () => {
       expect(data.reason).toContain('speak');
     });
 
-    it('inactive session pre-speak satisfies speak requirement for stop', async () => {
-      // Set main agent as active
+    it('background session speak satisfies speak requirement for stop', async () => {
+      // Enable voice responses (required for /api/speak to work)
+      await fetch(`${server.url}/api/voice-active`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ active: true }),
+      });
+
+      // Set main agent as selected
       await fetch(`${server.url}/api/hooks/post-tool`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -193,8 +213,8 @@ describe('Per-session state and session lifecycle', () => {
         body: JSON.stringify({ session_id: 'session-A', agent_id: 'subagent-B' }),
       });
 
-      // Subagent speaks (approved but no TTS, updates lastSpeakTimestamp)
-      const speakRes = await fetch(`${server.url}/api/hooks/pre-speak`, {
+      // Subagent pre-speak whitelists, then speak stores and sets lastSpeakTimestamp
+      const preSpeakRes = await fetch(`${server.url}/api/hooks/pre-speak`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -203,8 +223,15 @@ describe('Per-session state and session lifecycle', () => {
           tool_input: { text: 'My response' },
         }),
       });
-      const speakData = await speakRes.json() as any;
-      expect(speakData.decision).toBe('approve'); // Approved (no TTS for inactive)
+      const preSpeakData = await preSpeakRes.json() as any;
+      expect(preSpeakData.decision).toBe('approve');
+
+      // Call speak endpoint to actually set lastSpeakTimestamp
+      await fetch(`${server.url}/api/speak`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: 'My response' }),
+      });
 
       // Subagent tries to stop — should now approve
       const stopRes = await fetch(`${server.url}/api/hooks/stop`, {

--- a/src/__tests__/whitelist-routing.test.ts
+++ b/src/__tests__/whitelist-routing.test.ts
@@ -28,7 +28,7 @@ describe('Pre-speak whitelist and multi-session routing', () => {
       const data = await res.json() as any;
       expect(data.decision).toBe('approve');
       // session-A is now active
-      expect(server.activeCompositeKey).toBe(JSON.stringify(['session-A', 'main']));
+      expect(server.selectedSessionKey).toBe(JSON.stringify(['session-A', 'main']));
     });
 
     it('second session_id is inactive', async () => {
@@ -107,7 +107,7 @@ describe('Pre-speak whitelist and multi-session routing', () => {
     });
 
     it('speak endpoint returns success for non-whitelisted text (inactive session)', async () => {
-      // Activate a session first (so activeCompositeKey is set)
+      // Activate a session first (so selectedSessionKey is set)
       await fetch(`${server.url}/api/hooks/pre-speak`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -175,15 +175,15 @@ describe('Pre-speak whitelist and multi-session routing', () => {
       expect(data3.respondedCount).toBe(0);
     });
 
-    it('pre-speak for inactive session approves and stores in history', async () => {
-      // Set main agent as active
+    it('pre-speak for background session approves and whitelists text', async () => {
+      // Set main agent as selected
       await fetch(`${server.url}/api/hooks/post-tool`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ session_id: 'session-A' }),
       });
 
-      // subagent tries to speak
+      // subagent tries to speak — should be whitelisted (not blocked)
       const res = await fetch(`${server.url}/api/hooks/pre-speak`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -196,12 +196,8 @@ describe('Pre-speak whitelist and multi-session routing', () => {
       const data = await res.json() as any;
       expect(data.decision).toBe('approve');
 
-      // Verify text was stored in subagent-B's conversation history
-      const sessionBKey = JSON.stringify(['session-A', 'subagent-B']);
-      const sessionB = server.sessions.get(sessionBKey);
-      expect(sessionB).toBeDefined();
-      const assistantMessages = sessionB!.queue.messages.filter(m => m.role === 'assistant');
-      expect(assistantMessages.some(m => m.text === 'I am subagent B')).toBe(true);
+      // Verify text was whitelisted (all sessions now get whitelisted)
+      expect(server.speakWhitelist.has('I am subagent B')).toBe(true);
     });
   });
 
@@ -288,7 +284,7 @@ describe('Pre-speak whitelist and multi-session routing', () => {
       const data = await res.json() as any;
       expect(data.decision).toBe('approve');
       // Should have created a default key
-      expect(server.activeCompositeKey).toBe(JSON.stringify(['default', 'main']));
+      expect(server.selectedSessionKey).toBe(JSON.stringify(['default', 'main']));
     });
   });
 });

--- a/src/test-utils/test-server.ts
+++ b/src/test-utils/test-server.ts
@@ -197,7 +197,7 @@ export class TestServer {
 
   // Multi-session state
   public sessions = new Map<string, SessionState>();
-  public activeCompositeKey: string | null = null;
+  public selectedSessionKey: string | null = null;
   public speakWhitelist = new Map<string, { count: number; expiry: number; sessionKey: string }>();
   private whitelistTTL = 5000;
   public backgroundVoiceEnforcement = false;
@@ -248,8 +248,8 @@ export class TestServer {
   }
 
   private getActiveSession(): SessionState | null {
-    if (this.activeCompositeKey) {
-      const session = this.sessions.get(this.activeCompositeKey);
+    if (this.selectedSessionKey) {
+      const session = this.sessions.get(this.selectedSessionKey);
       if (session) return session;
     }
     // No active session set — only return default if no real sessions exist
@@ -270,13 +270,13 @@ export class TestServer {
     return this.getOrCreateSession(defaultKey);
   }
 
-  private isActiveKey(key: string): boolean {
-    return this.activeCompositeKey !== null && key === this.activeCompositeKey;
+  private isSelectedKey(key: string): boolean {
+    return this.selectedSessionKey !== null && key === this.selectedSessionKey;
   }
 
-  private registerIfFirst(key: string): void {
-    if (this.activeCompositeKey === null) {
-      this.activeCompositeKey = key;
+  private autoSelectIfNone(key: string): void {
+    if (this.selectedSessionKey === null) {
+      this.selectedSessionKey = key;
 
       // Migrate data from default session to first real session
       const parsed = JSON.parse(key) as [string, string];
@@ -297,30 +297,27 @@ export class TestServer {
         }
       }
     } else {
-      const currentActive = this.sessions.get(this.activeCompositeKey);
+      const currentSelected = this.sessions.get(this.selectedSessionKey);
       const parsed = JSON.parse(key) as [string, string];
       const newSessionId = parsed[0];
 
-      if (currentActive && currentActive.sessionId === 'default' && newSessionId !== 'default') {
-        // If the current active is a default session and this is a real session, upgrade
+      if (currentSelected && currentSelected.sessionId === 'default' && newSessionId !== 'default') {
+        // If the current selection is a default session and this is a real session, upgrade
         // Migrate data from default session
         const newSession = this.getOrCreateSession(key, newSessionId);
-        if (currentActive.queue.utterances.length > 0 || currentActive.queue.messages.length > 0) {
-          for (const utterance of currentActive.queue.utterances) {
+        if (currentSelected.queue.utterances.length > 0 || currentSelected.queue.messages.length > 0) {
+          for (const utterance of currentSelected.queue.utterances) {
             newSession.queue.utterances.push(utterance);
           }
-          for (const message of currentActive.queue.messages) {
+          for (const message of currentSelected.queue.messages) {
             newSession.queue.messages.push(message);
           }
-          currentActive.queue.utterances = [];
-          currentActive.queue.messages = [];
+          currentSelected.queue.utterances = [];
+          currentSelected.queue.messages = [];
         }
-        this.activeCompositeKey = key;
-      } else if (currentActive && currentActive.sessionId !== newSessionId && newSessionId !== 'default') {
-        // Different session_id means new Claude instance — always switch active
-        this.activeCompositeKey = key;
-        this.voicePreferences.voiceActive = false;
+        this.selectedSessionKey = key;
       }
+      // Other sessions don't auto-select — browser selection is authoritative
     }
   }
 
@@ -521,13 +518,12 @@ export class TestServer {
         return;
       }
 
-      // Check whitelist if multi-session is active
+      // Check whitelist if any session exists
       let whitelistSessionKey: string | undefined;
-      if (this.activeCompositeKey !== null) {
+      if (this.selectedSessionKey !== null) {
         const whitelistResult = this.checkWhitelist(text);
         if (!whitelistResult.matched) {
-          // Not whitelisted = inactive session. Pre-speak already stored text.
-          // Return success so the agent isn't confused.
+          // Not whitelisted — unexpected since pre-speak now always whitelists.
           res.json({
             success: true,
             message: 'Text spoken successfully',
@@ -538,16 +534,22 @@ export class TestServer {
         whitelistSessionKey = whitelistResult.sessionKey;
       }
 
+      // Only play TTS audio if the speaking session is the browser-selected one
+      const speakingSessionKey = whitelistSessionKey || this.selectedSessionKey;
+      const isBrowserSelected = !this.selectedSessionKey || speakingSessionKey === this.selectedSessionKey;
+
       try {
         // Use the session from the whitelist entry for correct routing
         const session = whitelistSessionKey
           ? (this.sessions.get(whitelistSessionKey) || this.getActiveSessionOrFirst())
           : this.getActiveSessionOrFirst();
 
-        // Use macOS say command for TTS (mocked in tests)
-        await execAsync(`say "${text.replace(/"/g, '\\"')}"`);
+        if (isBrowserSelected) {
+          // Use macOS say command for TTS (mocked in tests)
+          await execAsync(`say "${text.replace(/"/g, '\\"')}"`);
+        }
 
-        // Store assistant's response in conversation history
+        // Store assistant's response in conversation history (always, regardless of selection)
         session.queue.addAssistantMessage(text);
 
         // Mark all delivered utterances as responded
@@ -714,7 +716,7 @@ export class TestServer {
         sessionId: s.sessionId,
         agentId: s.agentId,
         agentType: s.agentType,
-        isActive: s.key === this.activeCompositeKey,
+        isActive: s.key === this.selectedSessionKey,
         lastActivity: s.lastActivity,
         utteranceCount: s.queue.utterances.length,
         messageCount: s.queue.messages.length,
@@ -723,7 +725,7 @@ export class TestServer {
 
       res.json({
         sessions: sessionList,
-        activeKey: this.activeCompositeKey,
+        activeKey: this.selectedSessionKey,
       });
     });
 
@@ -736,10 +738,10 @@ export class TestServer {
         return;
       }
 
-      this.activeCompositeKey = key;
+      this.selectedSessionKey = key;
       res.json({
         success: true,
-        activeKey: this.activeCompositeKey,
+        activeKey: this.selectedSessionKey,
       });
     });
 
@@ -759,11 +761,11 @@ export class TestServer {
     // Hook endpoints for testing
     this.app.post('/api/hooks/stop', (req, res) => {
       const { key, sessionId, agentId, agentType } = this.parseCompositeKey(req.body);
-      this.registerIfFirst(key);
+      this.autoSelectIfNone(key);
       const session = this.getOrCreateSession(key, sessionId, agentId, agentType);
 
       // Inactive session: enforce "must speak after tool use" when enforcement is on OR voice responses enabled
-      if (!this.isActiveKey(key)) {
+      if (!this.isSelectedKey(key)) {
         const enforceSpeak = this.backgroundVoiceEnforcement;
         if (enforceSpeak && session.lastToolUseTimestamp &&
           (!session.lastSpeakTimestamp || session.lastSpeakTimestamp < session.lastToolUseTimestamp)) {
@@ -802,51 +804,41 @@ export class TestServer {
       res.json({ decision: 'approve' });
     });
 
-    // Pre-speak hook
+    // Pre-speak hook — all sessions get whitelisted for TTS
+    // The /api/speak endpoint decides whether to actually play audio
+    // based on which session the browser has selected.
     this.app.post('/api/hooks/pre-speak', (req, res) => {
       const { key, sessionId, agentId, agentType } = this.parseCompositeKey(req.body);
-      this.registerIfFirst(key);
+      this.autoSelectIfNone(key);
       const session = this.getOrCreateSession(key, sessionId, agentId, agentType);
       const speakText = req.body?.tool_input?.text;
 
-      // Active session: check for pending utterances, whitelist text
-      if (this.isActiveKey(key)) {
-        const pendingUtterances = session.queue.utterances.filter(u => u.status === 'pending');
-        if (pendingUtterances.length > 0) {
-          res.json({
-            decision: 'block',
-            reason: `There are ${pendingUtterances.length} pending utterances. Please dequeue them before speaking.`
-          });
-          return;
-        }
-
-        // Whitelist the text for the speak endpoint with session key
-        if (speakText) {
-          this.addToWhitelist(speakText, key);
-        }
-
-        res.json({ decision: 'approve' });
+      // Check for pending utterances (applies to all sessions)
+      const pendingUtterances = session.queue.utterances.filter(u => u.status === 'pending');
+      if (pendingUtterances.length > 0) {
+        res.json({
+          decision: 'block',
+          reason: `There are ${pendingUtterances.length} pending utterances. Please dequeue them before speaking.`
+        });
         return;
       }
 
-      // Inactive session: store in that session's conversation history, approve without TTS
+      // Always whitelist the text (regardless of selected session)
       if (speakText) {
-        session.queue.addAssistantMessage(speakText);
-        session.lastSpeakTimestamp = new Date();
+        this.addToWhitelist(speakText, key);
       }
-      res.json({
-        decision: 'approve',
-      });
+
+      res.json({ decision: 'approve' });
     });
 
     // Post-tool hook
     this.app.post('/api/hooks/post-tool', (req, res) => {
       const { key, sessionId, agentId, agentType } = this.parseCompositeKey(req.body);
-      this.registerIfFirst(key);
+      this.autoSelectIfNone(key);
       const session = this.getOrCreateSession(key, sessionId, agentId, agentType);
 
       // Inactive session: still track tool use but don't route voice
-      if (!this.isActiveKey(key)) {
+      if (!this.isSelectedKey(key)) {
         session.lastToolUseTimestamp = new Date();
         res.json({ decision: 'approve' });
         return;
@@ -937,7 +929,7 @@ export class TestServer {
       speechRate: 200,
       feedbackSoundMode: 'continuous'
     };
-    this.activeCompositeKey = null;
+    this.selectedSessionKey = null;
     this.speakWhitelist.clear();
     this.backgroundVoiceEnforcement = false;
     clearTtsQueue();

--- a/src/unified-server.ts
+++ b/src/unified-server.ts
@@ -69,7 +69,7 @@ async function processTtsQueue() {
   try {
     const { audioId, filePath } = await renderTtsToFile(item.text, item.rate);
     // Check if a WS client is connected for this session — prefer WS delivery
-    const targetKey = item.sessionKey || activeCompositeKey;
+    const targetKey = item.sessionKey || selectedSessionKey;
     const wsClient = findWsClientForSession(targetKey);
     if (wsClient && wsClient.ws.readyState === WebSocket.OPEN) {
       serverAudioState.setTtsActive(true);
@@ -470,7 +470,7 @@ class ServerAudioState {
     if (!filePath) return;
 
     // Find a connected WS client to stream to
-    const targetKey = activeCompositeKey;
+    const targetKey = selectedSessionKey;
     const wsClient = findWsClientForSession(targetKey);
     if (!wsClient || wsClient.ws.readyState !== WebSocket.OPEN) return;
 
@@ -520,7 +520,10 @@ interface SessionState {
 }
 
 const sessions = new Map<string, SessionState>();
-let activeCompositeKey: string | null = null;
+// The server's selected session key — driven by browser selection.
+// Auto-set to the first session that registers (before browser connects),
+// then updated by browser's 'select-session' WS message.
+let selectedSessionKey: string | null = null;
 
 const SESSION_TTL_MS = 30 * 60 * 1000; // 30 minute TTL
 
@@ -544,12 +547,12 @@ function getOrCreateSession(key: string, sessionId?: string, agentId?: string | 
   return session;
 }
 
-function getActiveSession(): SessionState | null {
-  if (activeCompositeKey) {
-    const session = sessions.get(activeCompositeKey);
+function getSelectedSession(): SessionState | null {
+  if (selectedSessionKey) {
+    const session = sessions.get(selectedSessionKey);
     if (session) return session;
   }
-  // No active session set — only return default if no real sessions exist
+  // No selected session — only return default if no real sessions exist
   const hasRealSessions = Array.from(sessions.values()).some(s => s.sessionId !== 'default');
   if (!hasRealSessions) {
     const defaultKey = compositeKey('default');
@@ -567,9 +570,9 @@ function getSessionFromRequest(req: Request): SessionState {
   return getActiveSessionOrFirst();
 }
 
-// Get active session or return a 404-like response for browser endpoints
+// Get selected session or return a fallback for browser endpoints
 function getActiveSessionOrFirst(): SessionState {
-  const active = getActiveSession();
+  const active = getSelectedSession();
   if (active) return active;
   // If there are real sessions but none is active, return the first one
   const first = sessions.values().next().value;
@@ -585,8 +588,8 @@ function cleanupSessions(): void {
   for (const [key, session] of sessions) {
     if (now - session.lastActivity.getTime() > SESSION_TTL_MS) {
       sessions.delete(key);
-      const wasActive = key === activeCompositeKey;
-      if (wasActive) activeCompositeKey = null;
+      const wasActive = key === selectedSessionKey;
+      if (wasActive) selectedSessionKey = null;
       debugLog(`[Session] TTL cleanup: key=${key} lastActivity=${session.lastActivity.toISOString()}`);
     }
   }
@@ -1038,72 +1041,53 @@ function parseHookRequest(req: Request): { key: string; sessionId: string; agent
   return { key, sessionId, agentId, session };
 }
 
-// Pure check: is this key the active session?
-function isActiveKey(key: string): boolean {
-  return activeCompositeKey !== null && key === activeCompositeKey;
+// Pure check: is this key the browser-selected session?
+function isSelectedKey(key: string): boolean {
+  return selectedSessionKey !== null && key === selectedSessionKey;
 }
 
-// Register the first session seen as active (separated from isActiveKey to avoid side effects)
-function registerIfFirst(key: string): void {
-  if (activeCompositeKey === null) {
-    activeCompositeKey = key;
-    debugLog(`[Session] Active changed: ${null} → ${key}`);
+// Auto-select the first session that registers, only if no session is selected yet.
+// This handles voice input arriving before the browser connects.
+// Once the browser connects, it takes over via 'select-session' WS message.
+function autoSelectIfNone(key: string): void {
+  if (selectedSessionKey === null) {
+    selectedSessionKey = key;
+    debugLog(`[Session] Auto-selected (first session): ${key}`);
 
     // Check if there's a default session with data that should be migrated
     const parsed = JSON.parse(key) as [string, string];
     const newSessionId = parsed[0];
     if (newSessionId !== 'default') {
-      const defaultKey = compositeKey('default');
-      const defaultSession = sessions.get(defaultKey);
-      if (defaultSession && (defaultSession.queue.utterances.length > 0 || defaultSession.queue.messages.length > 0)) {
-        const newSession = getOrCreateSession(key, newSessionId, null, null);
-        for (const utterance of defaultSession.queue.utterances) {
-          newSession.queue.utterances.push(utterance);
-        }
-        for (const message of defaultSession.queue.messages) {
-          newSession.queue.messages.push(message);
-        }
-        debugLog(`[Session] Migrated ${defaultSession.queue.utterances.length} utterance(s) and ${defaultSession.queue.messages.length} message(s) from default → ${key}`);
-        defaultSession.queue.utterances = [];
-        defaultSession.queue.messages = [];
-      }
+      migrateDefaultSession(key, newSessionId);
     }
-  } else {
-    const currentActive = sessions.get(activeCompositeKey);
+  } else if (selectedSessionKey) {
+    // If current selection is a default session and this is a real session, upgrade
+    const currentSelected = sessions.get(selectedSessionKey);
     const parsed = JSON.parse(key) as [string, string];
     const newSessionId = parsed[0];
-
-    if (currentActive && currentActive.sessionId === 'default' && newSessionId !== 'default') {
-      // If the current active is a default session and this is a real session, upgrade.
-      // Migrate messages from the default session to the new session.
-      const newSession = getOrCreateSession(key, newSessionId, null, null);
-      if (currentActive.queue.utterances.length > 0 || currentActive.queue.messages.length > 0) {
-        for (const utterance of currentActive.queue.utterances) {
-          newSession.queue.utterances.push(utterance);
-        }
-        for (const message of currentActive.queue.messages) {
-          newSession.queue.messages.push(message);
-        }
-        currentActive.queue.utterances = [];
-        currentActive.queue.messages = [];
-        debugLog(`[Session] Migrated ${newSession.queue.utterances.length} utterance(s) and ${newSession.queue.messages.length} message(s) from default → ${key}`);
-      }
-      activeCompositeKey = key;
-      debugLog(`[Session] Active upgraded from default → ${key}`);
-    } else if (currentActive && currentActive.sessionId !== newSessionId && newSessionId !== 'default') {
-      // Different session_id — only switch if it's NOT a subagent of the current session
-      const incomingSession = sessions.get(key);
-      const isSubagent = incomingSession?.agentId && incomingSession.agentId !== 'main';
-      if (isSubagent) {
-        // Subagent sessions should NOT steal focus from the lead session
-        debugLog(`[Session] Subagent hook ignored for active switch: ${key} (active stays ${activeCompositeKey})`);
-      } else {
-        // Different non-subagent session — never steal active. The first session
-        // that registers owns the active slot for the server's lifetime.
-        // Use the /api/sessions/active endpoint to switch manually if needed.
-        debugLog(`[Session] New session ${key} ignored — active session already set (active stays ${activeCompositeKey})`);
-      }
+    if (currentSelected && currentSelected.sessionId === 'default' && newSessionId !== 'default') {
+      migrateDefaultSession(key, newSessionId);
+      selectedSessionKey = key;
+      debugLog(`[Session] Auto-selected (upgraded from default): ${key}`);
     }
+  }
+}
+
+// Migrate utterances and messages from the default session to a new session
+function migrateDefaultSession(newKey: string, newSessionId: string): void {
+  const defaultKey = compositeKey('default');
+  const defaultSession = sessions.get(defaultKey);
+  if (defaultSession && (defaultSession.queue.utterances.length > 0 || defaultSession.queue.messages.length > 0)) {
+    const newSession = getOrCreateSession(newKey, newSessionId, null, null);
+    for (const utterance of defaultSession.queue.utterances) {
+      newSession.queue.utterances.push(utterance);
+    }
+    for (const message of defaultSession.queue.messages) {
+      newSession.queue.messages.push(message);
+    }
+    debugLog(`[Session] Migrated ${defaultSession.queue.utterances.length} utterance(s) and ${defaultSession.queue.messages.length} message(s) from default → ${newKey}`);
+    defaultSession.queue.utterances = [];
+    defaultSession.queue.messages = [];
   }
 }
 
@@ -1113,18 +1097,18 @@ function logHookRequest(req: Request, endpoint: string): void {
   const agentId = req.body?.agent_id || null;
   const key = compositeKey(sessionId, agentId);
   const toolName = req.body?.tool_name;
-  const active = isActiveKey(key) ? 'active' : 'inactive';
-  debugLog(`[Hook] ${endpoint}: key=${key} active=${active === 'active'} tool=${toolName || 'n/a'}`);
+  const selected = isSelectedKey(key) ? 'selected' : 'background';
+  debugLog(`[Hook] ${endpoint}: key=${key} selected=${selected === 'selected'} tool=${toolName || 'n/a'}`);
 }
 
 // Dedicated hook endpoints that return in Claude's expected format
 app.post('/api/hooks/stop', async (req: Request, res: Response) => {
   logHookRequest(req, 'stop');
   const { key, session } = parseHookRequest(req);
-  registerIfFirst(key);
+  autoSelectIfNone(key);
 
-  // Inactive session (subagent): enforce "must speak after tool use" only when background enforcement is explicitly enabled
-  if (!isActiveKey(key)) {
+  // Background session (not browser-selected): enforce "must speak after tool use" only when background enforcement is enabled
+  if (!isSelectedKey(key)) {
     const enforceSpeak = backgroundVoiceEnforcement;
     if (enforceSpeak && session.lastToolUseTimestamp &&
       (!session.lastSpeakTimestamp || session.lastSpeakTimestamp < session.lastToolUseTimestamp)) {
@@ -1134,7 +1118,7 @@ app.post('/api/hooks/stop', async (req: Request, res: Response) => {
       });
       return;
     }
-    debugLog(`[Hook] stop: key=${key} active=false (approve)`);
+    debugLog(`[Hook] stop: key=${key} selected=false (approve)`);
     res.json({ decision: 'approve' });
     return;
   }
@@ -1157,45 +1141,33 @@ app.post('/api/hooks/stop', async (req: Request, res: Response) => {
 });
 
 // Pre-speak hook endpoint
+// All sessions get whitelisted for TTS — the /api/speak endpoint decides
+// whether to actually play audio based on which session the browser has selected.
 app.post('/api/hooks/pre-speak', (req: Request, res: Response) => {
   logHookRequest(req, 'pre-speak');
   const { key, session } = parseHookRequest(req);
-  registerIfFirst(key);
+  autoSelectIfNone(key);
   const toolInput = req.body?.tool_input;
   const speakText = toolInput?.text;
 
-  // Active session: approve and whitelist the text
-  if (isActiveKey(key)) {
-    const result = handleHookRequest('speak', session);
-    // If approved and we have text, add to whitelist
-    if (speakText && (result as any).decision !== 'block') {
-      addToWhitelist(speakText, key);
-    }
-    res.json(result);
-    return;
+  const result = handleHookRequest('speak', session);
+  // If approved and we have text, always whitelist (regardless of selected session)
+  if (speakText && (result as any).decision !== 'block') {
+    addToWhitelist(speakText, key);
   }
-
-  // Inactive session: store in that session's conversation history, approve without TTS
-  if (speakText) {
-    session.queue.addAssistantMessage(speakText);
-    session.lastSpeakTimestamp = new Date();
-    debugLog(`[Speak] Stored for inactive session: key=${key} text="${speakText.slice(0, 30)}..."`);
-  }
-  res.json({
-    decision: 'approve',
-  });
+  res.json(result);
 });
 
 // Post-tool hook endpoint
 app.post('/api/hooks/post-tool', (req: Request, res: Response) => {
   logHookRequest(req, 'post-tool');
   const { key, session } = parseHookRequest(req);
-  registerIfFirst(key);
+  autoSelectIfNone(key);
 
-  // Inactive session: still track tool use but don't route voice
-  if (!isActiveKey(key)) {
+  // Background session: still track tool use but don't show processing state in browser
+  if (!isSelectedKey(key)) {
     session.lastToolUseTimestamp = new Date();
-    debugLog(`[Hook] post-tool: key=${key} active=false (approve, tracking tool use)`);
+    debugLog(`[Hook] post-tool: key=${key} selected=false (approve, tracking tool use)`);
     res.json({ decision: 'approve' });
     return;
   }
@@ -1274,18 +1246,18 @@ app.get('/api/tts-events', (req: Request, res: Response) => {
 
   // Send current voice state so browser starts with correct UI.
   // Clients watching a different session get 'inactive'.
-  const initialState = (sessionKey === null || sessionKey === activeCompositeKey)
+  const initialState = (sessionKey === null || sessionKey === selectedSessionKey)
     ? serverAudioState.state
     : 'inactive';
   res.write(`data: ${JSON.stringify({
     type: 'voice-state',
     state: initialState,
-    sessionKey: activeCompositeKey
+    sessionKey: selectedSessionKey
   })}\n\n`);
 
   // Add client to map
   ttsClients.set(res, sessionKey);
-  debugLog(`[SSE] Client connected: session=${sessionKey || 'active'}`);
+  debugLog(`[SSE] Client connected: session=${sessionKey || 'selected'}`);
 
   // Remove client on disconnect
   res.on('close', () => {
@@ -1306,12 +1278,14 @@ app.get('/api/tts-events', (req: Request, res: Response) => {
   });
 });
 
-// Helper function to notify TTS clients viewing the active session
-function notifyTTSClients(text: string) {
-  const message = JSON.stringify({ type: 'speak', text, sessionKey: activeCompositeKey });
+// Helper function to notify TTS clients viewing a specific session.
+// Only sends to clients watching the given session (or all clients if viewingKey is null).
+function notifyTTSClients(text: string, sessionKey?: string) {
+  const targetKey = sessionKey || selectedSessionKey;
+  const message = JSON.stringify({ type: 'speak', text, sessionKey: targetKey });
   ttsClients.forEach((viewingKey, client) => {
-    // Send to clients watching the active session (null) or explicitly this session
-    if (viewingKey === null || viewingKey === activeCompositeKey) {
+    // Send to clients watching the target session (null means "watching selected")
+    if (viewingKey === null || viewingKey === targetKey) {
       client.write(`data: ${message}\n\n`);
     }
   });
@@ -1344,9 +1318,9 @@ function notifySessionReset() {
 
 // Helper function to notify clients viewing the active session about wait status
 function notifyWaitStatus(isWaiting: boolean) {
-  const message = JSON.stringify({ type: 'waitStatus', isWaiting, sessionKey: activeCompositeKey });
+  const message = JSON.stringify({ type: 'waitStatus', isWaiting, sessionKey: selectedSessionKey });
   ttsClients.forEach((viewingKey, client) => {
-    if (viewingKey === null || viewingKey === activeCompositeKey) {
+    if (viewingKey === null || viewingKey === selectedSessionKey) {
       client.write(`data: ${message}\n\n`);
     }
   });
@@ -1359,10 +1333,10 @@ function broadcastVoiceState(state: string): void {
   const message = JSON.stringify({
     type: 'voice-state',
     state,
-    sessionKey: activeCompositeKey
+    sessionKey: selectedSessionKey
   });
   ttsClients.forEach((viewingKey, client) => {
-    if (viewingKey === null || viewingKey === activeCompositeKey) {
+    if (viewingKey === null || viewingKey === selectedSessionKey) {
       client.write(`data: ${message}\n\n`);
     }
   });
@@ -1526,10 +1500,17 @@ function handleWsControlMessage(client: WsAudioClient, msg: { type: string; [key
       client.ws.send(JSON.stringify({ type: 'pong' }));
       break;
 
-    case 'select-session':
-      (client as any).selectedSessionKey = msg.sessionKey;
-      debugLog(`[WS] Client selected session: ${msg.sessionKey}`);
+    case 'select-session': {
+      const previousKey = selectedSessionKey;
+      const newKey = msg.sessionKey as string;
+      (client as any).selectedSessionKey = newKey;
+      // Browser selection is authoritative — update the server's selected session
+      if (newKey && sessions.has(newKey)) {
+        selectedSessionKey = newKey;
+      }
+      debugLog(`[WS] Browser selected session: ${previousKey} → ${newKey}`);
       break;
+    }
 
     default:
       debugLog(`[WS] Unknown message type: ${msg.type}`);
@@ -1749,7 +1730,7 @@ app.get('/api/sessions', (_req: Request, res: Response) => {
     sessionId: s.sessionId,
     agentId: s.agentId,
     agentType: s.agentType,
-    isActive: s.key === activeCompositeKey,
+    isActive: s.key === selectedSessionKey,
     lastActivity: s.lastActivity,
     utteranceCount: s.queue.utterances.length,
     messageCount: s.queue.messages.length,
@@ -1758,10 +1739,11 @@ app.get('/api/sessions', (_req: Request, res: Response) => {
 
   res.json({
     sessions: sessionList,
-    activeKey: activeCompositeKey,
+    activeKey: selectedSessionKey,
   });
 });
 
+// Browser can switch selected session via POST (backward compat — browser also uses WS select-session)
 app.post('/api/active-session', (req: Request, res: Response) => {
   const { key } = req.body;
 
@@ -1770,13 +1752,13 @@ app.post('/api/active-session', (req: Request, res: Response) => {
     return;
   }
 
-  const previousKey = activeCompositeKey;
-  activeCompositeKey = key;
-  debugLog(`[Session] Active changed: ${previousKey} → ${key}`);
+  const previousKey = selectedSessionKey;
+  selectedSessionKey = key;
+  debugLog(`[Session] Selected changed: ${previousKey} → ${key}`);
 
   res.json({
     success: true,
-    activeKey: activeCompositeKey,
+    activeKey: selectedSessionKey,
   });
 });
 
@@ -1800,14 +1782,14 @@ app.post('/api/speak', async (req: Request, res: Response) => {
   }
 
   // Check whitelist: only speak via TTS if text was approved by pre-speak hook
-  // Skip whitelist check if no multi-session is active (single session backward compat)
+  // Skip whitelist check if no session exists yet (single session backward compat)
   let whitelistSessionKey: string | undefined;
-  if (activeCompositeKey !== null) {
+  if (selectedSessionKey !== null) {
     const whitelistResult = checkWhitelist(text);
     if (!whitelistResult.matched) {
-      // Not whitelisted = inactive session. The pre-speak hook already stored the text
-      // in conversation history. Return success so the agent isn't confused.
-      debugLog(`[Speak] Non-whitelisted text (inactive session), returning success without TTS: "${text.slice(0, 30)}..."`);
+      // Not whitelisted — unexpected since pre-speak now always whitelists.
+      // Return success silently to avoid confusing the agent.
+      debugLog(`[Speak] Non-whitelisted text, returning success without TTS: "${text.slice(0, 30)}..."`);
       res.json({
         success: true,
         message: 'Text spoken successfully',
@@ -1818,23 +1800,31 @@ app.post('/api/speak', async (req: Request, res: Response) => {
     whitelistSessionKey = whitelistResult.sessionKey;
   }
 
+  // Only play TTS audio if the speaking session is the one the browser has selected.
+  // Background sessions get their text stored in conversation history but no audio.
+  const speakingSessionKey = whitelistSessionKey || selectedSessionKey;
+  const isBrowserSelected = !selectedSessionKey || speakingSessionKey === selectedSessionKey;
+
   try {
     // Use the session from the whitelist entry (the session that pre-speak approved),
-    // falling back to the active session for single-session backward compat
+    // falling back to the selected session for single-session backward compat
     const session = whitelistSessionKey
       ? (sessions.get(whitelistSessionKey) || getActiveSessionOrFirst())
       : getActiveSessionOrFirst();
 
-    // Always send text via SSE for conversation display + browser TTS
-    notifyTTSClients(text);
-    debugLog(`[Speak] Sent text to browser: "${text}"`);
+    if (isBrowserSelected) {
+      // Send text via SSE for conversation display + browser TTS
+      notifyTTSClients(text, speakingSessionKey || undefined);
+      debugLog(`[Speak] Sent text to browser: "${text}"`);
 
-    // Render TTS audio via macOS say command and stream over WebSocket
-    // This is async/non-blocking — the speak endpoint returns immediately
-    const sessionKey = whitelistSessionKey || activeCompositeKey;
-    enqueueTts(text, voicePreferences.speechRate, sessionKey).catch(err => {
-      debugLog(`[Speak] Failed to render system voice audio: ${err}`);
-    });
+      // Render TTS audio via macOS say command and stream over WebSocket
+      enqueueTts(text, voicePreferences.speechRate, speakingSessionKey).catch(err => {
+        debugLog(`[Speak] Failed to render system voice audio: ${err}`);
+      });
+    } else {
+      // Background session — store in conversation history but no TTS audio
+      debugLog(`[Speak] Background session ${speakingSessionKey} — storing without TTS: "${text.slice(0, 30)}..."`);
+    }
 
     // Store assistant's response in conversation history
     session.queue.addAssistantMessage(text);


### PR DESCRIPTION
## Summary

- Fixes TTS not playing for the browser-selected session when background agents or subagents are active
- Replaces the dual `activeCompositeKey`/`selectedSessionKey` concept with a single `selectedSessionKey` driven by browser selection
- Root cause: `activeCompositeKey` was permanently locked to the first session that registered (focus-stealing prevention from ec71aa8), so TTS was gated by the wrong key when the browser selected a different session

## Changes

- **Remove `activeCompositeKey`** — replaced with `selectedSessionKey` throughout server
- **Replace `registerIfFirst()`** with `autoSelectIfNone()` — only auto-selects the first session (before browser connects), no focus-stealing prevention needed
- **Browser's WS `select-session` message** now updates server's `selectedSessionKey` (browser selection is authoritative for all routing)
- **Pre-speak hook** now whitelists text for ALL sessions (not just selected) — `/api/speak` decides whether to play TTS
- **`/api/speak`** only plays TTS audio for the browser-selected session; background sessions still get text stored in conversation history
- **8 test files updated** — all 214 tests pass

## How it works now

1. First session that registers auto-selects (handles voice input before browser connects)
2. Browser connects → its session selection becomes authoritative
3. All sessions' speak calls get whitelisted by pre-speak hook
4. `/api/speak` checks if the speaking session matches the browser-selected session → plays TTS only for that one
5. Background sessions get their text stored in conversation history but no audio

## Test plan

- [x] All 214 existing tests pass
- [x] Build succeeds (no TypeScript errors)
- [ ] Manual test: start server, open browser, start 2+ Claude sessions, verify TTS plays for browser-selected session
- [ ] Manual test: switch browser to view a different session, verify TTS switches
- [ ] Manual test: background agent's speak calls don't produce audio when another session is selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)